### PR TITLE
fix: dashboard small-box icon class and Google Fonts

### DIFF
--- a/.memory/memory.yaml
+++ b/.memory/memory.yaml
@@ -19,3 +19,7 @@ items:
     tags: [decision, ui, ux, audit]
     count: 1
     created: "2026-07-28T10:36:32Z"
+  - text: "ADR: Dashboard small-box icon fix — Changed .icon to .small-box-icon in dashboard view (AdminLTE 4 CSS class), updated Google Fonts from Source Sans Pro to Source Sans 3 (AdminLTE 4 default), updated DESIGN.md documentation. No custom CSS needed — AdminLTE 4 already provides .small-box-icon styles."
+    tags: [decision, ui, dashboard, small-box]
+    count: 1
+    created: "2026-07-28T11:44:11Z"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Agent instructions:
 
 ### Fixed
 
+- **Dashboard small-box icon:** fixed icon class from `.icon` to `.small-box-icon` — AdminLTE 4 CSS targets `.small-box-icon` for absolute positioning (top-right, 70px, opacity .15) — icon was previously rendering at default inline position (left-bottom, small size)
+- **Google Fonts:** updated from `Source+Sans+Pro` (AdminLTE 3) to `Source+Sans+3` — matches AdminLTE 4 default `--bs-font-sans-serif`
+
 - **Password toggle:** broken show/hide button — JS queried `<i>` but HTML used `<span>`, causing TypeError
 - **Login error styling:** removed blanket `is-invalid` on both fields; flash message is now the sole error feedback
 - **Null safety:** added `$username ?? session('auth.username')` fallback in header and dashboard views

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -409,7 +409,7 @@ Use `p-0` on `card-body` when it wraps only a table so the table touches the car
         <h3><?= esc($count) ?></h3>
         <p>Label</p>
     </div>
-    <div class="icon">
+    <div class="small-box-icon">
         <i class="fas fa-users"></i>
     </div>
     <a href="#" class="small-box-footer">

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -16,7 +16,7 @@
                             <h3 class="text-truncate"><?= esc($username ?? session('auth.username')) ?></h3>
                             <p>Pengguna Aktif</p>
                         </div>
-                        <div class="icon">
+                        <div class="small-box-icon">
                             <i class="fas fa-user"></i>
                         </div>
                     </div>
@@ -27,7 +27,7 @@
                             <h3>NeoFeeder</h3>
                             <p>Service</p>
                         </div>
-                        <div class="icon">
+                        <div class="small-box-icon">
                             <i class="fas fa-database"></i>
                         </div>
                     </div>
@@ -38,7 +38,7 @@
                             <h3>Session</h3>
                             <p>Status</p>
                         </div>
-                        <div class="icon">
+                        <div class="small-box-icon">
                             <i class="fas fa-clock"></i>
                         </div>
                     </div>
@@ -49,7 +49,7 @@
                             <h3>BASE</h3>
                             <p>v0.1.0</p>
                         </div>
-                        <div class="icon">
+                        <div class="small-box-icon">
                             <i class="fas fa-cube"></i>
                         </div>
                     </div>

--- a/app/Views/layout/header.php
+++ b/app/Views/layout/header.php
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= esc($title ?? 'BASE - Bongaya Advanced Services Engine') ?></title>
-    <!-- Google Font: Source Sans Pro -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+    <!-- Google Font: Source Sans 3 (AdminLTE 4) -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+3:300,400,400i,600,700&display=fallback">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="<?= base_url('fontawesome/css/all.min.css') ?>">
     <!-- Bootstrap 5 -->


### PR DESCRIPTION
## Perbaikan Dashboard Small-Box Icon

**Masalah:** Icon dashboard cards kecil dan terletak di kiri bawah.

**Root cause:** View menggunakan class `.icon` tetapi AdminLTE 4 CSS menarget `.small-box-icon` — tanpa CSS match, icon render default inline (kiri-bawah, ukuran kecil).

### Perubahan

| File | Perubahan |
|------|-----------|
| `app/Views/dashboard/index.php` | 4x: `<div class="icon">` → `<div class="small-box-icon">` |
| `app/Views/layout/header.php` | Google Fonts: `Source+Sans+Pro` → `Source+Sans+3` |
| `DESIGN.md` | Section 4.4: `.icon` → `.small-box-icon` |

### Hasil

- Icon besar (70px), di kanan, opacity .15 — built-in AdminLTE 4 CSS
- Hover scale(1.1) — built-in
- Mobile hidden — built-in
- Font family Source Sans 3 sesuai AdminLTE 4 default

### Verifikasi

- `php -l` — lolos
- `npm run build` — lolos
- `vendor/bin/phpunit` — 15/15 lolos
- `php spark routes` — route valid
