### PR TITLE
feat(layout): align login, dashboard, header, sidebar, footer with AdminLTE 4 preview

### DIFF
--- a/.memory/memory.yaml
+++ b/.memory/memory.yaml
@@ -23,3 +23,11 @@ items:
     tags: [decision, ui, dashboard, small-box]
     count: 1
     created: "2026-07-28T11:44:11Z"
+  - text: "ADR: Prompt structure untuk UI audit — user request mencakup login page layout alignment + dashboard/layout alignment dengan AdminLTE 4 preview, tanpa menyentuh Neo Feeder data features"
+    tags: [workflow, prompt]
+    count: 1
+    created: "2026-07-28T12:17:07Z"
+  - text: "ADR: Login & Dashboard Layout alignment with AdminLTE 4 preview — Login page: <main>/<h1> markup, BASE title only, removed dead Remember"
+    tags: [decision, ui, layout, login, dashboard]
+    count: 1
+    created: "2026-07-28T12:31:09Z"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Agent instructions:
 - **Sidebar accessibility:** added `aria-label="Toggle sidebar"` on the hamburger menu link
 - **Username overflow:** added `text-truncate` on sidebar and dashboard username, CSS rule for navbar dropdown truncation
 - **Code style:** applied `php-cs-fixer` rules across `app/` and `tests/` — fixed import ordering, octal notation, anonymous class syntax
+- **Login page:** aligned markup with AdminLTE 4 — `<main class="login-box">`, `<h1 class="login-logo">`, removed subtitle
+- **Header user dropdown:** migrated to AdminLTE 4 `user-menu` pattern — icon-only trigger, username only inside dropdown `user-header`, `user-footer` with sign out
+- **Sidebar:** removed redundant user-panel (username moved to header dropdown)
+- **Footer:** updated copyright text to match AdminLTE 4 preview
+- **Dashboard small-box:** replaced `$username` heading with "Session" label for shorter card text
+- **Login button:** replaced checkbox+button row with `d-grid gap-2` full-width button (matching AdminLTE 4 login page)
 
 ### Fixed
 
@@ -54,6 +60,8 @@ Agent instructions:
 ### Removed
 
 - **welcome_message.php:** deleted unused default CI4 welcome page (Home controller always redirects)
+- **Login page:** removed dead "Remember me" checkbox (backend never processes it) and hidden "Forgot password?" link
+- **app.css:** removed unused navbar dropdown truncation rule (no longer needed after header dropdown restyle)
 
 ### Security
 _None yet._

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,18 +86,24 @@ view('layout/header')
             </li>
         </ul>
         <ul class="navbar-nav ms-auto">
-            <li class="nav-item dropdown">
-                <a class="nav-link" data-bs-toggle="dropdown" href="#">
-                    <i class="fas fa-user"></i> <?= esc($username) ?>
+            <li class="nav-item dropdown user-menu">
+                <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" aria-label="User menu">
+                    <i class="fas fa-user"></i>
                 </a>
-                <div class="dropdown-menu dropdown-menu-end">
-                    <form action="<?= base_url('logout') ?>" method="post">
-                        <?= csrf_field() ?>
-                        <button type="submit" class="dropdown-item">
-                            <i class="fas fa-sign-out-alt"></i> Logout
-                        </button>
-                    </form>
-                </div>
+                <ul class="dropdown-menu dropdown-menu-lg dropdown-menu-end">
+                    <li class="user-header text-bg-primary">
+                        <i class="fas fa-user"></i>
+                        <p><?= esc($username) ?></p>
+                    </li>
+                    <li class="user-footer">
+                        <form action="<?= base_url('logout') ?>" method="post">
+                            <?= csrf_field() ?>
+                            <button type="submit" class="btn btn-outline-primary">
+                                <i class="fas fa-right-from-bracket"></i> Sign out
+                            </button>
+                        </form>
+                    </li>
+                </ul>
             </li>
         </ul>
     </nav>
@@ -130,7 +136,7 @@ view('layout/header')
     </main>
 
     <footer class="app-footer">
-        <strong>&copy; <?= date('Y') ?> BASE - Bongaya Advanced Services Engine.</strong>
+        <strong>Copyright &copy; <?= date('Y') ?> BASE.</strong>
         All rights reserved.
     </footer>
 
@@ -255,23 +261,33 @@ Use `nav-header` for visual grouping labels between menu sections.
 
 Add `menu-open` to the parent `li` when a child page is active and the treeview should be expanded.
 
-### 2.6 User panel
+### 2.6 User menu (header dropdown)
+
+Username is displayed in the header user dropdown, not in the sidebar.
 
 ```html
-<div class="user-panel mt-3 pb-3 mb-3 d-flex">
-    <div class="image">
-        <span class="img-circle elevation-2 bg-info d-flex align-items-center justify-content-center"
-              style="width:34px;height:34px;">
+<li class="nav-item dropdown user-menu">
+    <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" aria-label="User menu">
+        <i class="fas fa-user"></i>
+    </a>
+    <ul class="dropdown-menu dropdown-menu-lg dropdown-menu-end">
+        <li class="user-header text-bg-primary">
             <i class="fas fa-user"></i>
-        </span>
-    </div>
-    <div class="info">
-        <a href="#" class="d-block"><?= esc(session('auth.username')) ?></a>
-    </div>
-</div>
+            <p><?= esc($username) ?></p>
+        </li>
+        <li class="user-footer">
+            <form action="<?= base_url('logout') ?>" method="post">
+                <?= csrf_field() ?>
+                <button type="submit" class="btn btn-outline-primary">
+                    <i class="fas fa-right-from-bracket"></i> Sign out
+                </button>
+            </form>
+        </li>
+    </ul>
+</li>
 ```
 
-Place the user panel inside `sidebar-wrapper`, before the `<nav>`.
+The `.user-menu` class on the `<li>` triggers AdminLTE 4's user menu styling. The trigger shows only a user icon — the username appears inside the dropdown menu's `.user-header`.
 
 ---
 

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -13,8 +13,8 @@
                 <div class="col-lg-3 col-6 mb-4">
                     <div class="small-box bg-info">
                         <div class="inner">
-                            <h3 class="text-truncate"><?= esc($username ?? session('auth.username')) ?></h3>
-                            <p>Pengguna Aktif</p>
+                            <h3>Session</h3>
+                            <p>Aktif</p>
                         </div>
                         <div class="small-box-icon">
                             <i class="fas fa-user"></i>

--- a/app/Views/layout/footer.php
+++ b/app/Views/layout/footer.php
@@ -1,7 +1,7 @@
     </main>
 
     <footer class="app-footer">
-        <strong>&copy; <?= esc(date('Y')) ?> BASE.</strong>
+        <strong>Copyright &copy; <?= esc(date('Y')) ?> BASE.</strong>
         All rights reserved.
     </footer>
 

--- a/app/Views/layout/header.php
+++ b/app/Views/layout/header.php
@@ -33,18 +33,24 @@
 
         <!-- Right navbar links -->
         <ul class="navbar-nav ms-auto">
-            <li class="nav-item dropdown">
-                <a class="nav-link" data-bs-toggle="dropdown" href="#">
-                    <i class="fas fa-user"></i> <?= esc($username ?? session('auth.username')) ?>
+            <li class="nav-item dropdown user-menu">
+                <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" aria-label="User menu">
+                    <i class="fas fa-user"></i>
                 </a>
-                <div class="dropdown-menu dropdown-menu-end">
-                    <form action="<?= base_url('logout') ?>" method="post">
-                        <?= csrf_field() ?>
-                        <button type="submit" class="dropdown-item">
-                            <i class="fas fa-right-from-bracket"></i> Logout
-                        </button>
-                    </form>
-                </div>
+                <ul class="dropdown-menu dropdown-menu-lg dropdown-menu-end">
+                    <li class="user-header text-bg-primary">
+                        <i class="fas fa-user"></i>
+                        <p><?= esc($username ?? session('auth.username')) ?></p>
+                    </li>
+                    <li class="user-footer">
+                        <form action="<?= base_url('logout') ?>" method="post">
+                            <?= csrf_field() ?>
+                            <button type="submit" class="btn btn-outline-primary">
+                                <i class="fas fa-right-from-bracket"></i> Sign out
+                            </button>
+                        </form>
+                    </li>
+                </ul>
             </li>
         </ul>
     </nav>

--- a/app/Views/layout/sidebar.php
+++ b/app/Views/layout/sidebar.php
@@ -6,18 +6,6 @@
         </div>
 
         <div class="sidebar-wrapper">
-            <!-- Sidebar user panel -->
-            <div class="user-panel mt-3 pb-3 mb-3 d-flex">
-                <div class="image">
-                    <span class="img-circle elevation-2 bg-info d-flex align-items-center justify-content-center" style="width:34px;height:34px;">
-                        <i class="fas fa-user"></i>
-                    </span>
-                </div>
-                <div class="info">
-                    <span class="d-block text-truncate"><?= esc($username ?? session('auth.username')) ?></span>
-                </div>
-            </div>
-
             <!-- Sidebar Menu -->
             <nav class="mt-2">
                 <ul class="nav sidebar-menu flex-column" data-lte-toggle="treeview" role="menu">

--- a/app/Views/login/login.php
+++ b/app/Views/login/login.php
@@ -19,10 +19,10 @@
 </head>
 <body class="login-page bg-body-secondary">
 
-<div class="login-box">
-    <div class="login-logo">
-        <a href="<?= base_url() ?>"><b>BASE</b> — Bongaya Advanced Services Engine</a>
-    </div>
+<main class="login-box">
+    <h1 class="login-logo">
+        <a href="<?= base_url() ?>"><b>BASE</b></a>
+    </h1>
 
     <div class="card">
         <div class="card-body login-card-body">
@@ -61,27 +61,13 @@
                     </button>
                 </div>
 
-                <div class="row align-items-center mb-3">
-                    <div class="col-8">
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" name="remember" id="remember" value="1">
-                            <label class="form-check-label" for="remember">Remember me</label>
-                        </div>
-                    </div>
-                    <div class="col-4 text-end">
-                        <a href="#" class="text-decoration-none text-muted small d-none">Forgot password?</a>
-                    </div>
-                </div>
-
-                <div class="row">
-                    <div class="col-12">
-                        <button type="submit" class="btn btn-primary w-100">Sign in</button>
-                    </div>
+                <div class="d-grid gap-2">
+                    <button type="submit" class="btn btn-primary">Sign in</button>
                 </div>
             </form>
         </div>
     </div>
-</div>
+</main>
 
 <!-- Bootstrap 5 -->
 <script src="<?= base_url('bootstrap/js/bootstrap.bundle.min.js') ?>"></script>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,9 +1,1 @@
 /* BASE custom styles */
-
-/* Username truncation in navbar dropdown */
-.app-header .dropdown-menu .d-block {
-    max-width: 200px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}


### PR DESCRIPTION
﻿### Perubahan

Sesuaikan halaman Login, Dashboard, dan layout (header, sidebar, footer) agar sedekat mungkin dengan preview asli AdminLTE 4.

### Login Page
- Markup: <main class="login-box"> dan <h1 class="login-logo"> sesuai AdminLTE 4
- Title cukup "BASE" saja (tanpa subtitle panjang)
- Hapus "Remember me" checkbox - backend tidak pernah memprosesnya
- Hapus "Forgot password?" link (sebelumnya disembunyikan dengan d-none)
- Tombol Sign in full-width dengan d-grid gap-2

### Header
- Dropdown user pindah ke pola user-menu AdminLTE 4
- Trigger hanya icon (fas fa-user) - username tidak ditampilkan di navbar
- Username muncul di dalam dropdown (user-header)
- Sign out di user-footer dengan tombol outline

### Sidebar
- Hapus user-panel - username pindah ke header dropdown, tidak perlu duplikasi

### Footer
- &copy; menjadi Copyright &copy; sesuai AdminLTE 4

### Dashboard
- Card pertama: ganti  (email panjang) menjadi "Session" / "Aktif"

### Dokumentasi
- CHANGELOG.md, DESIGN.md, .memory/memory.yaml diperbarui

### Verifikasi
- php -l: 0 syntax errors
- npm run build: semua assets tercopy
- vendor/bin/phpunit: 15/15 tests, 32 assertions, green
