### PR TITLE
feat: Profil PT page redesain layout

### DIFF
--- a/.memory/memory.yaml
+++ b/.memory/memory.yaml
@@ -55,3 +55,19 @@ items:
     tags: [decision, version, config]
     count: 1
     created: "2026-07-28T15:08:31Z"
+  - text: "ADR: Profil PT layout redesign — three-tier visual hierarchy. Hero card (card-outline-primary) with display-6 name + badge status, d-flex gap-4 info rows. Two card-info h-100 sub-cards (Kontak clickable links + Alamat paragraphs) side-by-side. Legalitas consolidated in hero. fa-fw for icon alignment. Equal-height via h-100 + d-flex flex-column + mt-auto. col-xxl-10 max-width wrapper. Documented in DESIGN.md 4.5 and 4.6."
+    tags: [decision, ui, layout, profilpt]
+    count: 1
+    created: "2026-07-28T16:27:56Z"
+  - text: "ADR: Website URL normalization — prepend https:// in controller if no protocol exists. Prevents browser from treating bare domain (www.example.com) as relative path."
+    tags: [decision, security, url]
+    count: 1
+    created: "2026-07-28T16:27:57Z"
+  - text: "ADR: Indonesian date format via strtr() month mapping — no system locale dependency. Mapping array covers all 12 months."
+    tags: [decision, date, i18n]
+    count: 1
+    created: "2026-07-28T16:27:57Z"
+  - text: "Bug: card-title overrides display-6 font-size/font-weight in Bootstrap 5.3 (card-title compiled after display-* in CSS, same specificity). Fix: never combine card-title with display-* on same element; use display-6 alone for hero headings."
+    tags: [bug, css, bootstrap]
+    count: 1
+    created: "2026-07-28T16:27:59Z"

--- a/.memory/memory.yaml
+++ b/.memory/memory.yaml
@@ -47,3 +47,7 @@ items:
     tags: [changelog, release, fix]
     count: 1
     created: "2026-07-28T13:44:23Z"
+  - text: "ADR: Profil PT dibuat sebagai halaman terpisah, bukan di dashboard → Context: ProfilPT adalah data reference yang jarang berubah, tidak cocok untuk dashboard (violates Hick's Law, Miller's Law). Dashboard dikosongkan untuk KPI operasional di masa depan. → Consequence: Controller + View + Route + Sidebar baru; Dashboard tidak berubah."
+    tags: [decision, feature, profilpt]
+    count: 1
+    created: "2026-07-28T14:58:43Z"

--- a/.memory/memory.yaml
+++ b/.memory/memory.yaml
@@ -51,3 +51,7 @@ items:
     tags: [decision, feature, profilpt]
     count: 1
     created: "2026-07-28T14:58:43Z"
+  - text: "ADR: AppVersion config → Context: dashboard version number was hardcoded (v0.1.0) while actual release was v0.2.0. Created `app/Config/AppVersion.php` with `$version` and `$buildDate` properties; dashboard reads from config. AGENTS.md release process updated with step to bump version. → Consequence: version auto-syncs across views, one source of truth."
+    tags: [decision, version, config]
+    count: 1
+    created: "2026-07-28T15:08:31Z"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,12 @@ Triggered when a feature/fix batch is ready for release (manager says "Rilis" or
 Steps:
 
 1. **Check `main` is up-to-date** — `git switch main && git pull origin main`
-2. **Move [Unreleased] to versioned release in CHANGELOG.md** — replace `## [Unreleased]` with `## [0.X.0] - YYYY-MM-DD`. Follow Keep a Changelog format. Ensure `[unreleased]` link reference is also updated.
-3. **Verify** — `vendor/bin/phpunit` green, `php -l` on all changed files, `npm run build` passes
-4. **Commit** — `chore: release v0.X.0`
-5. **Tag** — `git tag v0.X.0 && git push origin v0.X.0`
-6. **Create GitHub Release** — extract only the version section from CHANGELOG.md, not the whole file, and append the reference link definition so the version heading is clickable:
+2. **Update `app/Config/AppVersion.php`** — set `$version` to the new version number and `$buildDate` to today's date.
+3. **Move [Unreleased] to versioned release in CHANGELOG.md** — replace `## [Unreleased]` with `## [0.X.0] - YYYY-MM-DD`. Follow Keep a Changelog format. Ensure `[unreleased]` link reference is also updated.
+4. **Verify** — `vendor/bin/phpunit` green, `php -l` on all changed files, `npm run build` passes
+5. **Commit** — `chore: release v0.X.0`
+6. **Tag** — `git tag v0.X.0 && git push origin v0.X.0`
+7. **Create GitHub Release** — extract only the version section from CHANGELOG.md, not the whole file, and append the reference link definition so the version heading is clickable:
    ```powershell
    $notes = [regex]::Match((Get-Content CHANGELOG.md -Raw), "(?s)## \[0\.X\.0\].*?(?=\n## \[|\z)").Value
    $notes += "`r`n[0.X.0]: https://github.com/ffooll-bit/BASE/compare/v0.(X-1).0...v0.X.0"
@@ -88,8 +89,8 @@ Steps:
    Remove-Item release_notes.md
    ```
    > (Replace `X` with the actual major version numbers.)
-7. **Update docs** — mark released issues in OPEN_ISSUES.md as Released, move to archive section
-8. **Cleanup** — delete any stale branches that were already merged
+8. **Update docs** — mark released issues in OPEN_ISSUES.md as Released, move to archive section
+9. **Cleanup** — delete any stale branches that were already merged
 
 > Before every release, verify that `[unreleased]:` link at the bottom of CHANGELOG.md is updated to point to `HEAD`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ _None yet._
 
 - **Sidebar active state:** fixed route detection — `getPath()` returned `index.php/dashboard` instead of `dashboard`; now uses `current_url()` with `basename()` which handles both URL formats
 - **Profil PT card styling:** replaced `table-borderless` with `table` for visible row separators, `card-body p-0` with `card-body` for proper padding, `td` labels upgraded to `th scope="row"` for semantic correctness
+- **Profil PT layout:** merged two uneven cards into one balanced card with 2-column inner layout (6 rows each), removed Kelurahan (always `-`) and Fax (redundant)
 
 ### Removed
 _None yet._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,18 +41,12 @@ _None yet._
 - **UI consistency:** login page Google Font updated from `Source Sans Pro` (AdminLTE 3) to `Source Sans 3` (AdminLTE 4) to match the rest of the app
 - **Sidebar navigation:** added auto-detection of active page via `active` CSS class on current route
 - **Dashboard version:** replaced hardcoded `v0.1.0` with dynamic value from `config('AppVersion')->version`
-- **Profil PT page:** breadcrumb and page title unified to "Profil Perguruan Tinggi" for consistency
 - **Release process:** added step to update `app/Config/AppVersion.php` when releasing a new version
-- **Profil PT page layout:** redesigned with visual hierarchy — hero card with institution name + badge status, two side-by-side cards (Kontak + Alamat), and Legalitas card; pure AdminLTE 4 + Bootstrap with no custom CSS or horizontal lines
-- **Profil PT page polish:** badge now shows "Akreditasi A" (not bare "A"), prepended https:// to website URL, equal-height cards via `h-100` + `d-flex flex-column` + `mt-auto`, `fa-fw` for aligned icons, `display-6` hero name, limited max width via `col-xxl-10`, visual hierarchy via font-size and `small` class
-- **Profil PT hero:** moved SK Pendirian and Tanggal SK into hero card beneath identity info; removed standalone Legalitas card; Kepemilikan now shown with explicit label
-- **Profil PT hero:** merged Kode PT and Kepemilikan into one line, Tanggal SK now uses Indonesian month names (Januari, Februari, etc.)
+- **Profil PT page:** redesain layout dengan visual hierarchy — hero card `card-outline-primary` (nama `display-6` + badge Akreditasi, info identitas & legalitas dalam `d-flex gap-4`), dua card `card-info h-100` sejajar (Kontak dengan clickable links + Alamat), `fa-fw` untuk icon rata, equal-height via `d-flex flex-column` + `mt-auto`, prepend `https://` ke website, format tanggal Bahasa Indonesia via `strtr()`, lebar maksimal via `col-xxl-10`
 
 ### Fixed
 
 - **Sidebar active state:** fixed route detection — `getPath()` returned `index.php/dashboard` instead of `dashboard`; now uses `current_url()` with `basename()` which handles both URL formats
-- **Profil PT card styling:** replaced `table-borderless` with `table` for visible row separators, `card-body p-0` with `card-body` for proper padding, `td` labels upgraded to `th scope="row"` for semantic correctness
-- **Profil PT layout:** merged two uneven cards into one balanced card with 2-column inner layout (6 rows each), removed Kelurahan (always `-`) and Fax (redundant)
 
 ### Removed
 _None yet._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,12 @@ _None yet._
 - **Route:** `GET /profil-pt` → `ProfilPT::index` with auth+csrf filters
 
 ### Changed
-_None yet._
+
+- **UI consistency:** login page Google Font updated from `Source Sans Pro` (AdminLTE 3) to `Source Sans 3` (AdminLTE 4) to match the rest of the app
+- **Sidebar navigation:** added auto-detection of active page via `active` CSS class on current route
+- **Dashboard version:** replaced hardcoded `v0.1.0` with dynamic value from `config('AppVersion')->version`
+- **Profil PT page:** breadcrumb and page title unified to "Profil Perguruan Tinggi" for consistency
+- **Release process:** added step to update `app/Config/AppVersion.php` when releasing a new version
 
 ### Fixed
 _None yet._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _None yet._
 - **Dashboard version:** replaced hardcoded `v0.1.0` with dynamic value from `config('AppVersion')->version`
 - **Profil PT page:** breadcrumb and page title unified to "Profil Perguruan Tinggi" for consistency
 - **Release process:** added step to update `app/Config/AppVersion.php` when releasing a new version
+- **Profil PT page layout:** redesigned with visual hierarchy — hero card with institution name + badge status, two side-by-side cards (Kontak + Alamat), and Legalitas card; pure AdminLTE 4 + Bootstrap with no custom CSS or horizontal lines
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _None yet._
 - **Profil PT page layout:** redesigned with visual hierarchy — hero card with institution name + badge status, two side-by-side cards (Kontak + Alamat), and Legalitas card; pure AdminLTE 4 + Bootstrap with no custom CSS or horizontal lines
 - **Profil PT page polish:** badge now shows "Akreditasi A" (not bare "A"), prepended https:// to website URL, equal-height cards via `h-100` + `d-flex flex-column` + `mt-auto`, `fa-fw` for aligned icons, `display-6` hero name, limited max width via `col-xxl-10`, visual hierarchy via font-size and `small` class
 - **Profil PT hero:** moved SK Pendirian and Tanggal SK into hero card beneath identity info; removed standalone Legalitas card; Kepemilikan now shown with explicit label
+- **Profil PT hero:** merged Kode PT and Kepemilikan into one line, Tanggal SK now uses Indonesian month names (Januari, Februari, etc.)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ _None yet._
 ## [Unreleased]
 
 ### Added
-_None yet._
+
+- **Profil PT page:** dedicated page (`/profil-pt`) displaying institution profile data from NeoFeeder API — identity, contact, address, and legalitas in two AdminLTE cards; sidebar navigation item added
+- **Route:** `GET /profil-pt` → `ProfilPT::index` with auth+csrf filters
 
 ### Changed
 _None yet._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ _None yet._
 - **Release process:** added step to update `app/Config/AppVersion.php` when releasing a new version
 - **Profil PT page layout:** redesigned with visual hierarchy — hero card with institution name + badge status, two side-by-side cards (Kontak + Alamat), and Legalitas card; pure AdminLTE 4 + Bootstrap with no custom CSS or horizontal lines
 - **Profil PT page polish:** badge now shows "Akreditasi A" (not bare "A"), prepended https:// to website URL, equal-height cards via `h-100` + `d-flex flex-column` + `mt-auto`, `fa-fw` for aligned icons, `display-6` hero name, limited max width via `col-xxl-10`, visual hierarchy via font-size and `small` class
+- **Profil PT hero:** moved SK Pendirian and Tanggal SK into hero card beneath identity info; removed standalone Legalitas card; Kepemilikan now shown with explicit label
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,9 @@ _None yet._
 - **Release process:** added step to update `app/Config/AppVersion.php` when releasing a new version
 
 ### Fixed
-_None yet._
+
+- **Sidebar active state:** fixed route detection — `getPath()` returned `index.php/dashboard` instead of `dashboard`; now uses `current_url()` with `basename()` which handles both URL formats
+- **Profil PT card styling:** replaced `table-borderless` with `table` for visible row separators, `card-body p-0` with `card-body` for proper padding, `td` labels upgraded to `th scope="row"` for semantic correctness
 
 ### Removed
 _None yet._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ _None yet._
 - **Profil PT page:** breadcrumb and page title unified to "Profil Perguruan Tinggi" for consistency
 - **Release process:** added step to update `app/Config/AppVersion.php` when releasing a new version
 - **Profil PT page layout:** redesigned with visual hierarchy — hero card with institution name + badge status, two side-by-side cards (Kontak + Alamat), and Legalitas card; pure AdminLTE 4 + Bootstrap with no custom CSS or horizontal lines
+- **Profil PT page polish:** badge now shows "Akreditasi A" (not bare "A"), prepended https:// to website URL, equal-height cards via `h-100` + `d-flex flex-column` + `mt-auto`, `fa-fw` for aligned icons, `display-6` hero name, limited max width via `col-xxl-10`, visual hierarchy via font-size and `small` class
 
 ### Fixed
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -427,6 +427,89 @@ Use `p-0` on `card-body` when it wraps only a table so the table touches the car
 
 Available backgrounds: `bg-info`, `bg-success`, `bg-warning`, `bg-danger`, `bg-primary`.
 
+### 4.5 Hero card (profile/detail header)
+
+For entity detail pages where the institution/entity name is the most prominent element:
+
+```html
+<div class="card card-outline card-primary mb-4">
+    <div class="card-body">
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+            <div>
+                <h2 class="display-6 mb-1"><?= esc($entity['name']) ?></h2>
+                <div class="d-flex gap-4 small text-muted">
+                    <div><span>Field A:</span> <?= esc($entity['field_a'] ?? '-') ?></div>
+                    <div><span>Field B:</span> <?= esc($entity['field_b'] ?? '-') ?></div>
+                </div>
+            </div>
+            <span class="badge bg-success fs-6">Status: <?= esc($entity['status'] ?? '-') ?></span>
+        </div>
+        <hr class="my-3">
+        <div class="d-flex gap-4 small">
+            <div><span class="text-muted">Sub Info 1:</span> <?= esc($entity['info_1'] ?? '-') ?></div>
+            <div><span class="text-muted">Sub Info 2:</span> <?= esc($entity['info_2'] ?? '-') ?></div>
+        </div>
+    </div>
+</div>
+```
+
+| Element | Class | Purpose |
+|---------|-------|---------|
+| Card | `card card-outline card-primary` | Colored border, transparent background — hero distinction |
+| Name | `display-6` | Large, lightweight heading (300 weight) — never combine with `card-title` |
+| Info rows | `d-flex gap-4 small text-muted` | Compact secondary info side by side |
+| Badge | `badge bg-success fs-6` | Visual status indicator with readable font-size |
+| Divider | `hr my-3` | Separates identity from secondary grouping |
+| Sub info | `d-flex gap-4 small` | Legalitas, dates, or less prominent data |
+
+### 4.6 Detail info card (equal-height pair)
+
+For side-by-side detail cards that must be the same height:
+
+```html
+<div class="row">
+    <div class="col-md-6 mb-4">
+        <div class="card card-info h-100">
+            <div class="card-header">
+                <h3 class="card-title">Group A</h3>
+            </div>
+            <div class="card-body d-flex flex-column">
+                <div class="fs-6 mb-2">
+                    <i class="fas fa-phone text-muted me-2 fa-fw"></i> <?= esc($item['phone'] ?? '-') ?>
+                </div>
+                <div class="fs-6 mb-2">
+                    <i class="fas fa-envelope text-muted me-2 fa-fw"></i>
+                    <a href="mailto:<?= esc($item['email'], 'url') ?>"><?= esc($item['email']) ?></a>
+                </div>
+                <div class="fs-6 mt-auto">
+                    <i class="fas fa-globe text-muted me-2 fa-fw"></i>
+                    <a href="<?= esc($website, 'url') ?>" target="_blank"><?= esc($item['website']) ?></a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6 mb-4">
+        <div class="card card-info h-100">
+            <div class="card-header">
+                <h3 class="card-title">Group B</h3>
+            </div>
+            <div class="card-body d-flex flex-column">
+                <p class="fs-6 mb-1"><?= esc($item['address'] ?? '-') ?></p>
+                <p class="fs-6 mb-0 mt-auto">Kode Pos: <?= esc($item['postal_code'] ?? '-') ?></p>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+| Technique | Classes | Effect |
+|-----------|---------|--------|
+| Equal height | `h-100` on card | Both cards fill the column height |
+| Content alignment | `d-flex flex-column` on card-body | Flex column for vertical positioning |
+| Push to bottom | `mt-auto` on last item | Last element stays at card bottom |
+| Icon width | `fa-fw` on icon | Fixed 1.25em width, all icons align |
+| Card variant | `card-info` | Colored header bar for visual grouping |
+
 ---
 
 ## 5. Forms

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -40,7 +40,7 @@ class App extends BaseConfig
      * something else. If you have configured your web server to remove this file
      * from your site URIs, set this variable to an empty string.
      */
-    public string $indexPage = 'index.php';
+    public string $indexPage = '';
 
     /**
      * --------------------------------------------------------------------------

--- a/app/Config/AppVersion.php
+++ b/app/Config/AppVersion.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class AppVersion extends BaseConfig
+{
+    public string $version = '0.2.0';
+    public string $buildDate = '2026-07-28';
+}

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -16,3 +16,4 @@ $routes->get('login', 'Login::index');
 $routes->post('login', 'Login::attemptLogin');
 $routes->post('logout', 'Login::logout');
 $routes->get('dashboard', 'Dashboard::index');
+$routes->get('profil-pt', 'ProfilPT::index');

--- a/app/Controllers/ProfilPT.php
+++ b/app/Controllers/ProfilPT.php
@@ -10,6 +10,7 @@ class ProfilPT extends BaseController
         $profilPT = null;
         $error = null;
         $tanggalSK = '-';
+        $website = '-';
 
         $token = session('auth.token');
         if ($token !== null) {
@@ -19,6 +20,14 @@ class ProfilPT extends BaseController
                 $tanggalSK = isset($profilPT['tanggal_sk_pendirian'])
                     ? date('d F Y', strtotime($profilPT['tanggal_sk_pendirian']))
                     : '-';
+                $rawUrl = $profilPT['website'] ?? '';
+                if ($rawUrl === '') {
+                    $website = '-';
+                } else {
+                    $website = preg_match('#^https?://#i', $rawUrl)
+                        ? $rawUrl
+                        : 'https://' . $rawUrl;
+                }
             } else {
                 $error = $response['error_msg'] ?? 'Gagal memuat data profil perguruan tinggi.';
             }
@@ -26,7 +35,7 @@ class ProfilPT extends BaseController
 
         return view('layout/header', ['username' => $username, 'title' => 'Profil Perguruan Tinggi'])
             . view('layout/sidebar', ['username' => $username])
-            . view('profil_pt/index', compact('username', 'profilPT', 'error', 'tanggalSK'))
+            . view('profil_pt/index', compact('username', 'profilPT', 'error', 'tanggalSK', 'website'))
             . view('layout/footer');
     }
 }

--- a/app/Controllers/ProfilPT.php
+++ b/app/Controllers/ProfilPT.php
@@ -20,7 +20,7 @@ class ProfilPT extends BaseController
             }
         }
 
-        return view('layout/header', ['username' => $username, 'title' => 'Profil PT'])
+        return view('layout/header', ['username' => $username, 'title' => 'Profil Perguruan Tinggi'])
             . view('layout/sidebar', ['username' => $username])
             . view('profil_pt/index', compact('username', 'profilPT', 'error'))
             . view('layout/footer');

--- a/app/Controllers/ProfilPT.php
+++ b/app/Controllers/ProfilPT.php
@@ -12,13 +12,20 @@ class ProfilPT extends BaseController
         $tanggalSK = '-';
         $website = '-';
 
+        $bulan = [
+            'January' => 'Januari', 'February' => 'Februari', 'March' => 'Maret',
+            'April' => 'April', 'May' => 'Mei', 'June' => 'Juni',
+            'July' => 'Juli', 'August' => 'Agustus', 'September' => 'September',
+            'October' => 'Oktober', 'November' => 'November', 'December' => 'Desember',
+        ];
+
         $token = session('auth.token');
         if ($token !== null) {
             $response = service('neoFeeder')->getProfilPT($token);
             if (($response['error_code'] ?? -1) === 0 && isset($response['data'][0])) {
                 $profilPT = $response['data'][0];
                 $tanggalSK = isset($profilPT['tanggal_sk_pendirian'])
-                    ? date('d F Y', strtotime($profilPT['tanggal_sk_pendirian']))
+                    ? strtr(date('d F Y', strtotime($profilPT['tanggal_sk_pendirian'])), $bulan)
                     : '-';
                 $rawUrl = $profilPT['website'] ?? '';
                 if ($rawUrl === '') {

--- a/app/Controllers/ProfilPT.php
+++ b/app/Controllers/ProfilPT.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Controllers;
+
+class ProfilPT extends BaseController
+{
+    public function index()
+    {
+        $username = service('auth')->getCurrentUser();
+        $profilPT = null;
+        $error = null;
+
+        $token = session('auth.token');
+        if ($token !== null) {
+            $response = service('neoFeeder')->getProfilPT($token);
+            if (($response['error_code'] ?? -1) === 0 && isset($response['data'][0])) {
+                $profilPT = $response['data'][0];
+            } else {
+                $error = $response['error_msg'] ?? 'Gagal memuat data profil perguruan tinggi.';
+            }
+        }
+
+        return view('layout/header', ['username' => $username, 'title' => 'Profil PT'])
+            . view('layout/sidebar', ['username' => $username])
+            . view('profil_pt/index', compact('username', 'profilPT', 'error'))
+            . view('layout/footer');
+    }
+}

--- a/app/Controllers/ProfilPT.php
+++ b/app/Controllers/ProfilPT.php
@@ -9,12 +9,16 @@ class ProfilPT extends BaseController
         $username = service('auth')->getCurrentUser();
         $profilPT = null;
         $error = null;
+        $tanggalSK = '-';
 
         $token = session('auth.token');
         if ($token !== null) {
             $response = service('neoFeeder')->getProfilPT($token);
             if (($response['error_code'] ?? -1) === 0 && isset($response['data'][0])) {
                 $profilPT = $response['data'][0];
+                $tanggalSK = isset($profilPT['tanggal_sk_pendirian'])
+                    ? date('d F Y', strtotime($profilPT['tanggal_sk_pendirian']))
+                    : '-';
             } else {
                 $error = $response['error_msg'] ?? 'Gagal memuat data profil perguruan tinggi.';
             }
@@ -22,7 +26,7 @@ class ProfilPT extends BaseController
 
         return view('layout/header', ['username' => $username, 'title' => 'Profil Perguruan Tinggi'])
             . view('layout/sidebar', ['username' => $username])
-            . view('profil_pt/index', compact('username', 'profilPT', 'error'))
+            . view('profil_pt/index', compact('username', 'profilPT', 'error', 'tanggalSK'))
             . view('layout/footer');
     }
 }

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -47,7 +47,7 @@
                     <div class="small-box bg-secondary">
                         <div class="inner">
                             <h3>BASE</h3>
-                            <p>v0.1.0</p>
+                            <p>v<?= config('AppVersion')->version ?></p>
                         </div>
                         <div class="small-box-icon">
                             <i class="fas fa-cube"></i>

--- a/app/Views/layout/sidebar.php
+++ b/app/Views/layout/sidebar.php
@@ -7,18 +7,19 @@
 
         <div class="sidebar-wrapper">
             <!-- Sidebar Menu -->
+            <?php $currentUri = trim(service('uri')->getPath(), '/'); ?>
             <nav class="mt-2">
                 <ul class="nav sidebar-menu flex-column" data-lte-toggle="treeview" role="menu">
                     <li class="nav-item">
-                        <a href="<?= base_url('dashboard') ?>" class="nav-link">
+                        <a href="<?= base_url('dashboard') ?>" class="nav-link <?= $currentUri === 'dashboard' ? 'active' : '' ?>">
                             <i class="nav-icon fas fa-gauge-high"></i>
                             <p>Dashboard</p>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="<?= base_url('profil-pt') ?>" class="nav-link">
+                        <a href="<?= base_url('profil-pt') ?>" class="nav-link <?= $currentUri === 'profil-pt' ? 'active' : '' ?>">
                             <i class="nav-icon fas fa-university"></i>
-                            <p>Profil PT</p>
+                            <p>Profil Perguruan Tinggi</p>
                         </a>
                     </li>
                 </ul>

--- a/app/Views/layout/sidebar.php
+++ b/app/Views/layout/sidebar.php
@@ -15,6 +15,12 @@
                             <p>Dashboard</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="<?= base_url('profil-pt') ?>" class="nav-link">
+                            <i class="nav-icon fas fa-university"></i>
+                            <p>Profil PT</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/app/Views/layout/sidebar.php
+++ b/app/Views/layout/sidebar.php
@@ -7,17 +7,17 @@
 
         <div class="sidebar-wrapper">
             <!-- Sidebar Menu -->
-            <?php $currentUri = trim(service('uri')->getPath(), '/'); ?>
+            <?php $currentUrl = (string) current_url(); $currentRoute = basename(parse_url($currentUrl, PHP_URL_PATH)); ?>
             <nav class="mt-2">
                 <ul class="nav sidebar-menu flex-column" data-lte-toggle="treeview" role="menu">
                     <li class="nav-item">
-                        <a href="<?= base_url('dashboard') ?>" class="nav-link <?= $currentUri === 'dashboard' ? 'active' : '' ?>">
+                        <a href="<?= base_url('dashboard') ?>" class="nav-link <?= $currentRoute === 'dashboard' ? 'active' : '' ?>">
                             <i class="nav-icon fas fa-gauge-high"></i>
                             <p>Dashboard</p>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="<?= base_url('profil-pt') ?>" class="nav-link <?= $currentUri === 'profil-pt' ? 'active' : '' ?>">
+                        <a href="<?= base_url('profil-pt') ?>" class="nav-link <?= $currentRoute === 'profil-pt' ? 'active' : '' ?>">
                             <i class="nav-icon fas fa-university"></i>
                             <p>Profil Perguruan Tinggi</p>
                         </a>

--- a/app/Views/login/login.php
+++ b/app/Views/login/login.php
@@ -6,8 +6,8 @@
     <title>BASE | Log in</title>
     <link rel="icon" type="image/x-icon" href="<?= base_url('favicon.ico') ?>">
 
-    <!-- Google Font: Source Sans Pro -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+    <!-- Google Font: Source Sans 3 (AdminLTE 4) -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+3:300,400,400i,600,700&display=fallback">
     <!-- Font Awesome 6 -->
     <link rel="stylesheet" href="<?= base_url('fontawesome/css/all.min.css') ?>">
     <!-- Bootstrap 5 -->

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -37,68 +37,58 @@
                 <h3 class="card-title">Informasi Perguruan Tinggi</h3>
             </div>
             <div class="card-body">
-                <div class="row">
-                    <div class="col-md-6">
-                        <table class="table table-sm mb-0">
-                            <tbody>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap" style="width:140px">Nama PT</th>
-                                    <td><?= esc($profilPT['nama_perguruan_tinggi'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Kode PT</th>
-                                    <td><?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Status Akreditasi</th>
-                                    <td><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Kepemilikan</th>
-                                    <td><?= esc($profilPT['nama_status_milik'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Telepon</th>
-                                    <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Email</th>
-                                    <td><?= esc($profilPT['email'] ?? '-') ?></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="col-md-6">
-                        <table class="table table-sm mb-0">
-                            <tbody>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap" style="width:140px">Alamat</th>
-                                    <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Wilayah</th>
-                                    <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Kode Pos</th>
-                                    <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Website</th>
-                                    <td><?= esc($profilPT['website'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">SK Pendirian</th>
-                                    <td><?= esc($profilPT['sk_pendirian'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Tanggal SK</th>
-                                    <td><?= esc(isset($profilPT['tanggal_sk_pendirian']) ? date('d-m-Y', strtotime($profilPT['tanggal_sk_pendirian'])) : '-') ?></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                <table class="table table-sm table-borderless mb-0">
+                    <tbody>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap" style="width:140px">Nama PT</th>
+                            <td><?= esc($profilPT['nama_perguruan_tinggi'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Kode PT</th>
+                            <td><?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Status Akreditasi</th>
+                            <td><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Kepemilikan</th>
+                            <td><?= esc($profilPT['nama_status_milik'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Telepon</th>
+                            <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Email</th>
+                            <td><?= esc($profilPT['email'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Alamat</th>
+                            <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Wilayah</th>
+                            <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Kode Pos</th>
+                            <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Website</th>
+                            <td><?= esc($profilPT['website'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">SK Pendirian</th>
+                            <td><?= esc($profilPT['sk_pendirian'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-nowrap">Tanggal SK</th>
+                            <td><?= esc(isset($profilPT['tanggal_sk_pendirian']) ? date('d-m-Y', strtotime($profilPT['tanggal_sk_pendirian'])) : '-') ?></td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
         <?php endif; ?>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -33,73 +33,85 @@
 
         <?php if ($profilPT): ?>
 
-        <div class="card card-outline card-primary">
-            <div class="card-body">
-                <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
-                    <div>
-                        <h2 class="card-title h2 mb-1"><?= esc($profilPT['nama_perguruan_tinggi']) ?></h2>
-                        <div class="text-muted">
-                            Kode PT: <?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?>
-                            &middot; <?= esc($profilPT['nama_status_milik'] ?? '-') ?>
+        <div class="row justify-content-center">
+            <div class="col-xxl-10">
+
+                <div class="card card-outline card-primary mb-4">
+                    <div class="card-body">
+                        <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                            <div>
+                                <h2 class="card-title display-6 mb-1"><?= esc($profilPT['nama_perguruan_tinggi']) ?></h2>
+                                <div class="text-muted small">
+                                    Kode PT: <?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?>
+                                    &middot; <?= esc($profilPT['nama_status_milik'] ?? '-') ?>
+                                </div>
+                            </div>
+                            <span class="badge bg-success fs-6">Akreditasi <?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></span>
                         </div>
                     </div>
-                    <span class="badge bg-success fs-6"><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></span>
                 </div>
-            </div>
-        </div>
 
-        <div class="row">
-            <div class="col-md-6 mb-4">
-                <div class="card">
+                <div class="row">
+                    <div class="col-md-6 mb-4">
+                        <div class="card h-100">
+                            <div class="card-header">
+                                <h3 class="card-title"><i class="fas fa-address-card"></i> Kontak</h3>
+                            </div>
+                            <div class="card-body d-flex flex-column">
+                                <div class="fs-6 mb-2">
+                                    <i class="fas fa-phone text-muted me-2 fa-fw"></i> <?= esc($profilPT['telepon'] ?? '-') ?>
+                                </div>
+                                <div class="fs-6 mb-2">
+                                    <i class="fas fa-fax text-muted me-2 fa-fw"></i> <?= esc($profilPT['faximile'] ?? '-') ?>
+                                </div>
+                                <div class="fs-6 mb-2">
+                                    <i class="fas fa-envelope text-muted me-2 fa-fw"></i>
+                                    <?php if (!empty($profilPT['email'])): ?>
+                                        <a href="mailto:<?= esc($profilPT['email'], 'url') ?>"><?= esc($profilPT['email']) ?></a>
+                                    <?php else: ?>
+                                        -
+                                    <?php endif; ?>
+                                </div>
+                                <div class="fs-6 mt-auto">
+                                    <i class="fas fa-globe text-muted me-2 fa-fw"></i>
+                                    <?php if ($website !== '-'): ?>
+                                        <a href="<?= esc($website, 'url') ?>" target="_blank"><?= esc($profilPT['website'] ?? $website) ?></a>
+                                    <?php else: ?>
+                                        -
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6 mb-4">
+                        <div class="card h-100">
+                            <div class="card-header">
+                                <h3 class="card-title"><i class="fas fa-map-marker-alt"></i> Alamat</h3>
+                            </div>
+                            <div class="card-body d-flex flex-column">
+                                <p class="fs-6 mb-1"><?= esc($profilPT['jalan'] ?? '-') ?></p>
+                                <p class="fs-6 mb-1"><?= esc($profilPT['kelurahan'] ?? '-') ?></p>
+                                <p class="fs-6 mb-1"><?= esc($profilPT['nama_wilayah'] ?? '-') ?></p>
+                                <p class="fs-6 mb-0 mt-auto">Kode Pos: <?= esc($profilPT['kode_pos'] ?? '-') ?></p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mb-4">
                     <div class="card-header">
-                        <h3 class="card-title"><i class="fas fa-address-card"></i> Kontak</h3>
+                        <h3 class="card-title"><i class="fas fa-gavel"></i> Legalitas Pendirian</h3>
                     </div>
                     <div class="card-body">
-                        <div class="mb-2"><i class="fas fa-phone text-muted me-2" style="width:1.25rem"></i> <?= esc($profilPT['telepon'] ?? '-') ?></div>
-                        <div class="mb-2"><i class="fas fa-fax text-muted me-2" style="width:1.25rem"></i> <?= esc($profilPT['faximile'] ?? '-') ?></div>
-                        <div class="mb-2"><i class="fas fa-envelope text-muted me-2" style="width:1.25rem"></i>
-                            <?php if (!empty($profilPT['email'])): ?>
-                                <a href="mailto:<?= esc($profilPT['email'], 'url') ?>"><?= esc($profilPT['email']) ?></a>
-                            <?php else: ?>
-                                -
-                            <?php endif; ?>
-                        </div>
-                        <div class="mb-0"><i class="fas fa-globe text-muted me-2" style="width:1.25rem"></i>
-                            <?php if (!empty($profilPT['website'])): ?>
-                                <a href="<?= esc($profilPT['website'], 'url') ?>" target="_blank"><?= esc($profilPT['website']) ?></a>
-                            <?php else: ?>
-                                -
-                            <?php endif; ?>
-                        </div>
+                        <dl class="row mb-0">
+                            <dt class="col-sm-2 text-muted small fw-normal">SK Pendirian</dt>
+                            <dd class="col-sm-10 fs-6"><?= esc($profilPT['sk_pendirian'] ?? '-') ?></dd>
+                            <dt class="col-sm-2 text-muted small fw-normal">Tanggal SK</dt>
+                            <dd class="col-sm-10 fs-6"><?= esc($tanggalSK) ?></dd>
+                        </dl>
                     </div>
                 </div>
-            </div>
-            <div class="col-md-6 mb-4">
-                <div class="card">
-                    <div class="card-header">
-                        <h3 class="card-title"><i class="fas fa-map-marker-alt"></i> Alamat</h3>
-                    </div>
-                    <div class="card-body">
-                        <p class="mb-1"><?= esc($profilPT['jalan'] ?? '-') ?></p>
-                        <p class="mb-1"><?= esc($profilPT['kelurahan'] ?? '-') ?></p>
-                        <p class="mb-1"><?= esc($profilPT['nama_wilayah'] ?? '-') ?></p>
-                        <p class="mb-0">Kode Pos: <?= esc($profilPT['kode_pos'] ?? '-') ?></p>
-                    </div>
-                </div>
-            </div>
-        </div>
 
-        <div class="card">
-            <div class="card-header">
-                <h3 class="card-title"><i class="fas fa-gavel"></i> Legalitas Pendirian</h3>
-            </div>
-            <div class="card-body">
-                <dl class="row mb-0">
-                    <dt class="col-sm-2 text-muted fw-normal">SK Pendirian</dt>
-                    <dd class="col-sm-10"><?= esc($profilPT['sk_pendirian'] ?? '-') ?></dd>
-                    <dt class="col-sm-2 text-muted fw-normal">Tanggal SK</dt>
-                    <dd class="col-sm-10"><?= esc($tanggalSK) ?></dd>
-                </dl>
             </div>
         </div>
 

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -44,51 +44,59 @@
                     </colgroup>
                     <tbody>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">Nama PT</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Nama PT</th>
                             <td><?= esc($profilPT['nama_perguruan_tinggi'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">Kode PT</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Kode PT</th>
                             <td><?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">Status Akreditasi</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Status Akreditasi</th>
                             <td><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">Kepemilikan</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Kepemilikan</th>
                             <td><?= esc($profilPT['nama_status_milik'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">Telepon</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Telepon</th>
                             <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">Email</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Fax</th>
+                            <td><?= esc($profilPT['faximile'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-end">Email</th>
                             <td><?= esc($profilPT['email'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">Alamat</th>
-                            <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal">Wilayah</th>
-                            <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal">Kode Pos</th>
-                            <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal">Website</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Website</th>
                             <td><?= esc($profilPT['website'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">SK Pendirian</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Alamat</th>
+                            <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-end">Kelurahan</th>
+                            <td><?= esc($profilPT['kelurahan'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-end">Wilayah</th>
+                            <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-end">Kode Pos</th>
+                            <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row" class="text-muted fw-normal text-end">SK Pendirian</th>
                             <td><?= esc($profilPT['sk_pendirian'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal">Tanggal SK</th>
+                            <th scope="row" class="text-muted fw-normal text-end">Tanggal SK</th>
                             <td><?= esc(isset($profilPT['tanggal_sk_pendirian']) ? date('d-m-Y', strtotime($profilPT['tanggal_sk_pendirian'])) : '-') ?></td>
                         </tr>
                     </tbody>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -1,0 +1,119 @@
+<div class="app-content-header">
+    <div class="container-fluid">
+        <div class="row mb-2">
+            <div class="col-sm-6">
+                <h3 class="m-0">Profil Perguruan Tinggi</h3>
+            </div>
+            <div class="col-sm-6">
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb float-sm-end">
+                        <li class="breadcrumb-item"><a href="<?= base_url('dashboard') ?>">Home</a></li>
+                        <li class="breadcrumb-item active">Profil PT</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="app-content">
+    <div class="container-fluid">
+
+        <?php if ($error): ?>
+            <div class="alert alert-danger alert-dismissible">
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                <i class="fas fa-times-circle"></i> <?= esc($error) ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($profilPT === null && !$error): ?>
+            <div class="alert alert-info">
+                <i class="fas fa-info-circle"></i> Silakan login untuk melihat data profil perguruan tinggi.
+            </div>
+        <?php endif; ?>
+
+        <?php if ($profilPT): ?>
+        <div class="row">
+            <div class="col-md-6 mb-4">
+                <div class="card card-info">
+                    <div class="card-header">
+                        <h3 class="card-title">Identitas & Kontak</h3>
+                    </div>
+                    <div class="card-body p-0">
+                        <table class="table table-sm table-borderless mb-0">
+                            <tr>
+                                <td style="width:140px" class="text-muted">Nama PT</td>
+                                <td><?= esc($profilPT['nama_perguruan_tinggi'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Kode PT</td>
+                                <td><?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Status Akreditasi</td>
+                                <td><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Kepemilikan</td>
+                                <td><?= esc($profilPT['nama_status_milik'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Telepon</td>
+                                <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Fax</td>
+                                <td><?= esc($profilPT['faximile'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Email</td>
+                                <td><?= esc($profilPT['email'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Website</td>
+                                <td><?= esc($profilPT['website'] ?? '-') ?></td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 mb-4">
+                <div class="card card-secondary">
+                    <div class="card-header">
+                        <h3 class="card-title">Alamat & Legalitas</h3>
+                    </div>
+                    <div class="card-body p-0">
+                        <table class="table table-sm table-borderless mb-0">
+                            <tr>
+                                <td style="width:140px" class="text-muted">Alamat</td>
+                                <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Kelurahan</td>
+                                <td><?= esc($profilPT['kelurahan'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Wilayah</td>
+                                <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Kode Pos</td>
+                                <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">SK Pendirian</td>
+                                <td><?= esc($profilPT['sk_pendirian'] ?? '-') ?></td>
+                            </tr>
+                            <tr>
+                                <td class="text-muted">Tanggal SK</td>
+                                <td><?= esc(isset($profilPT['tanggal_sk_pendirian']) ? date('d-m-Y', strtotime($profilPT['tanggal_sk_pendirian'])) : '-') ?></td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <?php endif; ?>
+
+    </div>
+</div>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -8,7 +8,7 @@
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb float-sm-end">
                         <li class="breadcrumb-item"><a href="<?= base_url('dashboard') ?>">Home</a></li>
-                        <li class="breadcrumb-item active">Profil PT</li>
+                        <li class="breadcrumb-item active">Profil Perguruan Tinggi</li>
                     </ol>
                 </nav>
             </div>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -58,9 +58,9 @@
 
                 <div class="row">
                     <div class="col-md-6 mb-4">
-                        <div class="card h-100">
+                        <div class="card card-info h-100">
                             <div class="card-header">
-                                <h3 class="card-title"><i class="fas fa-address-card"></i> Kontak</h3>
+                                <h3 class="card-title">Kontak</h3>
                             </div>
                             <div class="card-body d-flex flex-column">
                                 <div class="fs-6 mb-2">
@@ -89,9 +89,9 @@
                         </div>
                     </div>
                     <div class="col-md-6 mb-4">
-                        <div class="card h-100">
+                        <div class="card card-info h-100">
                             <div class="card-header">
-                                <h3 class="card-title"><i class="fas fa-map-marker-alt"></i> Alamat</h3>
+                                <h3 class="card-title">Alamat</h3>
                             </div>
                             <div class="card-body d-flex flex-column">
                                 <p class="fs-6 mb-1"><?= esc($profilPT['jalan'] ?? '-') ?></p>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -37,54 +37,58 @@
                 <h3 class="card-title">Informasi Perguruan Tinggi</h3>
             </div>
             <div class="card-body">
-                <table class="table table-sm table-borderless mb-0">
+                <table class="table table-sm table-borderless mb-0" style="table-layout:fixed">
+                    <colgroup>
+                        <col style="width:50%">
+                        <col style="width:50%">
+                    </colgroup>
                     <tbody>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap" style="width:140px">Nama PT</th>
+                            <th scope="row" class="text-muted fw-normal">Nama PT</th>
                             <td><?= esc($profilPT['nama_perguruan_tinggi'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Kode PT</th>
+                            <th scope="row" class="text-muted fw-normal">Kode PT</th>
                             <td><?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Status Akreditasi</th>
+                            <th scope="row" class="text-muted fw-normal">Status Akreditasi</th>
                             <td><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Kepemilikan</th>
+                            <th scope="row" class="text-muted fw-normal">Kepemilikan</th>
                             <td><?= esc($profilPT['nama_status_milik'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Telepon</th>
+                            <th scope="row" class="text-muted fw-normal">Telepon</th>
                             <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Email</th>
+                            <th scope="row" class="text-muted fw-normal">Email</th>
                             <td><?= esc($profilPT['email'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Alamat</th>
+                            <th scope="row" class="text-muted fw-normal">Alamat</th>
                             <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Wilayah</th>
+                            <th scope="row" class="text-muted fw-normal">Wilayah</th>
                             <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Kode Pos</th>
+                            <th scope="row" class="text-muted fw-normal">Kode Pos</th>
                             <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Website</th>
+                            <th scope="row" class="text-muted fw-normal">Website</th>
                             <td><?= esc($profilPT['website'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">SK Pendirian</th>
+                            <th scope="row" class="text-muted fw-normal">SK Pendirian</th>
                             <td><?= esc($profilPT['sk_pendirian'] ?? '-') ?></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="text-muted fw-normal text-nowrap">Tanggal SK</th>
+                            <th scope="row" class="text-muted fw-normal">Tanggal SK</th>
                             <td><?= esc(isset($profilPT['tanggal_sk_pendirian']) ? date('d-m-Y', strtotime($profilPT['tanggal_sk_pendirian'])) : '-') ?></td>
                         </tr>
                     </tbody>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -40,7 +40,7 @@
                     <div class="card-body">
                         <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
                             <div>
-                                <h2 class="card-title display-6 mb-1"><?= esc($profilPT['nama_perguruan_tinggi']) ?></h2>
+                                <h2 class="display-6 mb-1"><?= esc($profilPT['nama_perguruan_tinggi']) ?></h2>
                                 <div class="text-muted small">
                                     Kode PT: <?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?>
                                     &middot; <?= esc($profilPT['nama_status_milik'] ?? '-') ?>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -38,40 +38,42 @@
                     <div class="card-header">
                         <h3 class="card-title">Identitas & Kontak</h3>
                     </div>
-                    <div class="card-body p-0">
-                        <table class="table table-sm table-borderless mb-0">
-                            <tr>
-                                <td style="width:140px" class="text-muted">Nama PT</td>
-                                <td><?= esc($profilPT['nama_perguruan_tinggi'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Kode PT</td>
-                                <td><?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Status Akreditasi</td>
-                                <td><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Kepemilikan</td>
-                                <td><?= esc($profilPT['nama_status_milik'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Telepon</td>
-                                <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Fax</td>
-                                <td><?= esc($profilPT['faximile'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Email</td>
-                                <td><?= esc($profilPT['email'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Website</td>
-                                <td><?= esc($profilPT['website'] ?? '-') ?></td>
-                            </tr>
+                    <div class="card-body">
+                        <table class="table table-sm mb-0">
+                            <tbody>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap" style="width:140px">Nama PT</th>
+                                    <td><?= esc($profilPT['nama_perguruan_tinggi'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Kode PT</th>
+                                    <td><?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Status Akreditasi</th>
+                                    <td><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Kepemilikan</th>
+                                    <td><?= esc($profilPT['nama_status_milik'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Telepon</th>
+                                    <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Fax</th>
+                                    <td><?= esc($profilPT['faximile'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Email</th>
+                                    <td><?= esc($profilPT['email'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Website</th>
+                                    <td><?= esc($profilPT['website'] ?? '-') ?></td>
+                                </tr>
+                            </tbody>
                         </table>
                     </div>
                 </div>
@@ -82,32 +84,34 @@
                     <div class="card-header">
                         <h3 class="card-title">Alamat & Legalitas</h3>
                     </div>
-                    <div class="card-body p-0">
-                        <table class="table table-sm table-borderless mb-0">
-                            <tr>
-                                <td style="width:140px" class="text-muted">Alamat</td>
-                                <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Kelurahan</td>
-                                <td><?= esc($profilPT['kelurahan'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Wilayah</td>
-                                <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Kode Pos</td>
-                                <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">SK Pendirian</td>
-                                <td><?= esc($profilPT['sk_pendirian'] ?? '-') ?></td>
-                            </tr>
-                            <tr>
-                                <td class="text-muted">Tanggal SK</td>
-                                <td><?= esc(isset($profilPT['tanggal_sk_pendirian']) ? date('d-m-Y', strtotime($profilPT['tanggal_sk_pendirian'])) : '-') ?></td>
-                            </tr>
+                    <div class="card-body">
+                        <table class="table table-sm mb-0">
+                            <tbody>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap" style="width:140px">Alamat</th>
+                                    <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Kelurahan</th>
+                                    <td><?= esc($profilPT['kelurahan'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Wilayah</th>
+                                    <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Kode Pos</th>
+                                    <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">SK Pendirian</th>
+                                    <td><?= esc($profilPT['sk_pendirian'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Tanggal SK</th>
+                                    <td><?= esc(isset($profilPT['tanggal_sk_pendirian']) ? date('d-m-Y', strtotime($profilPT['tanggal_sk_pendirian'])) : '-') ?></td>
+                                </tr>
+                            </tbody>
                         </table>
                     </div>
                 </div>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -41,12 +41,15 @@
                         <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
                             <div>
                                 <h2 class="display-6 mb-1"><?= esc($profilPT['nama_perguruan_tinggi']) ?></h2>
-                                <div class="text-muted small">
-                                    Kode PT: <?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?>
-                                    &middot; <?= esc($profilPT['nama_status_milik'] ?? '-') ?>
-                                </div>
+                                <div class="text-muted small mb-1">Kode PT: <?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></div>
+                                <div class="text-muted small">Kepemilikan: <?= esc($profilPT['nama_status_milik'] ?? '-') ?></div>
                             </div>
                             <span class="badge bg-success fs-6">Akreditasi <?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></span>
+                        </div>
+                        <hr class="my-3">
+                        <div class="d-flex gap-4 small">
+                            <div><span class="text-muted">SK Pendirian:</span> <?= esc($profilPT['sk_pendirian'] ?? '-') ?></div>
+                            <div><span class="text-muted">Tanggal SK:</span> <?= esc($tanggalSK) ?></div>
                         </div>
                     </div>
                 </div>
@@ -95,20 +98,6 @@
                                 <p class="fs-6 mb-0 mt-auto">Kode Pos: <?= esc($profilPT['kode_pos'] ?? '-') ?></p>
                             </div>
                         </div>
-                    </div>
-                </div>
-
-                <div class="card mb-4">
-                    <div class="card-header">
-                        <h3 class="card-title"><i class="fas fa-gavel"></i> Legalitas Pendirian</h3>
-                    </div>
-                    <div class="card-body">
-                        <dl class="row mb-0">
-                            <dt class="col-sm-2 text-muted small fw-normal">SK Pendirian</dt>
-                            <dd class="col-sm-10 fs-6"><?= esc($profilPT['sk_pendirian'] ?? '-') ?></dd>
-                            <dt class="col-sm-2 text-muted small fw-normal">Tanggal SK</dt>
-                            <dd class="col-sm-10 fs-6"><?= esc($tanggalSK) ?></dd>
-                        </dl>
                     </div>
                 </div>
 

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -32,77 +32,77 @@
         <?php endif; ?>
 
         <?php if ($profilPT): ?>
-        <div class="card card-info">
-            <div class="card-header">
-                <h3 class="card-title">Informasi Perguruan Tinggi</h3>
-            </div>
+
+        <div class="card card-outline card-primary">
             <div class="card-body">
-                <table class="table table-sm table-borderless mb-0" style="table-layout:fixed">
-                    <colgroup>
-                        <col style="width:50%">
-                        <col style="width:50%">
-                    </colgroup>
-                    <tbody>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Nama PT</th>
-                            <td><?= esc($profilPT['nama_perguruan_tinggi'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Kode PT</th>
-                            <td><?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Status Akreditasi</th>
-                            <td><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Kepemilikan</th>
-                            <td><?= esc($profilPT['nama_status_milik'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Telepon</th>
-                            <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Fax</th>
-                            <td><?= esc($profilPT['faximile'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Email</th>
-                            <td><?= esc($profilPT['email'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Website</th>
-                            <td><?= esc($profilPT['website'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Alamat</th>
-                            <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Kelurahan</th>
-                            <td><?= esc($profilPT['kelurahan'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Wilayah</th>
-                            <td><?= esc($profilPT['nama_wilayah'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Kode Pos</th>
-                            <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">SK Pendirian</th>
-                            <td><?= esc($profilPT['sk_pendirian'] ?? '-') ?></td>
-                        </tr>
-                        <tr>
-                            <th scope="row" class="text-muted fw-normal text-end">Tanggal SK</th>
-                            <td><?= esc(isset($profilPT['tanggal_sk_pendirian']) ? date('d-m-Y', strtotime($profilPT['tanggal_sk_pendirian'])) : '-') ?></td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                    <div>
+                        <h2 class="card-title h2 mb-1"><?= esc($profilPT['nama_perguruan_tinggi']) ?></h2>
+                        <div class="text-muted">
+                            Kode PT: <?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?>
+                            &middot; <?= esc($profilPT['nama_status_milik'] ?? '-') ?>
+                        </div>
+                    </div>
+                    <span class="badge bg-success fs-6"><?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></span>
+                </div>
             </div>
         </div>
+
+        <div class="row">
+            <div class="col-md-6 mb-4">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title"><i class="fas fa-address-card"></i> Kontak</h3>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-2"><i class="fas fa-phone text-muted me-2" style="width:1.25rem"></i> <?= esc($profilPT['telepon'] ?? '-') ?></div>
+                        <div class="mb-2"><i class="fas fa-fax text-muted me-2" style="width:1.25rem"></i> <?= esc($profilPT['faximile'] ?? '-') ?></div>
+                        <div class="mb-2"><i class="fas fa-envelope text-muted me-2" style="width:1.25rem"></i>
+                            <?php if (!empty($profilPT['email'])): ?>
+                                <a href="mailto:<?= esc($profilPT['email'], 'url') ?>"><?= esc($profilPT['email']) ?></a>
+                            <?php else: ?>
+                                -
+                            <?php endif; ?>
+                        </div>
+                        <div class="mb-0"><i class="fas fa-globe text-muted me-2" style="width:1.25rem"></i>
+                            <?php if (!empty($profilPT['website'])): ?>
+                                <a href="<?= esc($profilPT['website'], 'url') ?>" target="_blank"><?= esc($profilPT['website']) ?></a>
+                            <?php else: ?>
+                                -
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6 mb-4">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title"><i class="fas fa-map-marker-alt"></i> Alamat</h3>
+                    </div>
+                    <div class="card-body">
+                        <p class="mb-1"><?= esc($profilPT['jalan'] ?? '-') ?></p>
+                        <p class="mb-1"><?= esc($profilPT['kelurahan'] ?? '-') ?></p>
+                        <p class="mb-1"><?= esc($profilPT['nama_wilayah'] ?? '-') ?></p>
+                        <p class="mb-0">Kode Pos: <?= esc($profilPT['kode_pos'] ?? '-') ?></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title"><i class="fas fa-gavel"></i> Legalitas Pendirian</h3>
+            </div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-sm-2 text-muted fw-normal">SK Pendirian</dt>
+                    <dd class="col-sm-10"><?= esc($profilPT['sk_pendirian'] ?? '-') ?></dd>
+                    <dt class="col-sm-2 text-muted fw-normal">Tanggal SK</dt>
+                    <dd class="col-sm-10"><?= esc($tanggalSK) ?></dd>
+                </dl>
+            </div>
+        </div>
+
         <?php endif; ?>
 
     </div>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -32,13 +32,13 @@
         <?php endif; ?>
 
         <?php if ($profilPT): ?>
-        <div class="row">
-            <div class="col-md-6 mb-4">
-                <div class="card card-info">
-                    <div class="card-header">
-                        <h3 class="card-title">Identitas & Kontak</h3>
-                    </div>
-                    <div class="card-body">
+        <div class="card card-info">
+            <div class="card-header">
+                <h3 class="card-title">Informasi Perguruan Tinggi</h3>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-6">
                         <table class="table table-sm mb-0">
                             <tbody>
                                 <tr>
@@ -62,38 +62,18 @@
                                     <td><?= esc($profilPT['telepon'] ?? '-') ?></td>
                                 </tr>
                                 <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Fax</th>
-                                    <td><?= esc($profilPT['faximile'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
                                     <th scope="row" class="text-muted fw-normal text-nowrap">Email</th>
                                     <td><?= esc($profilPT['email'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Website</th>
-                                    <td><?= esc($profilPT['website'] ?? '-') ?></td>
                                 </tr>
                             </tbody>
                         </table>
                     </div>
-                </div>
-            </div>
-
-            <div class="col-md-6 mb-4">
-                <div class="card card-secondary">
-                    <div class="card-header">
-                        <h3 class="card-title">Alamat & Legalitas</h3>
-                    </div>
-                    <div class="card-body">
+                    <div class="col-md-6">
                         <table class="table table-sm mb-0">
                             <tbody>
                                 <tr>
                                     <th scope="row" class="text-muted fw-normal text-nowrap" style="width:140px">Alamat</th>
                                     <td><?= esc($profilPT['jalan'] ?? '-') ?></td>
-                                </tr>
-                                <tr>
-                                    <th scope="row" class="text-muted fw-normal text-nowrap">Kelurahan</th>
-                                    <td><?= esc($profilPT['kelurahan'] ?? '-') ?></td>
                                 </tr>
                                 <tr>
                                     <th scope="row" class="text-muted fw-normal text-nowrap">Wilayah</th>
@@ -102,6 +82,10 @@
                                 <tr>
                                     <th scope="row" class="text-muted fw-normal text-nowrap">Kode Pos</th>
                                     <td><?= esc($profilPT['kode_pos'] ?? '-') ?></td>
+                                </tr>
+                                <tr>
+                                    <th scope="row" class="text-muted fw-normal text-nowrap">Website</th>
+                                    <td><?= esc($profilPT['website'] ?? '-') ?></td>
                                 </tr>
                                 <tr>
                                     <th scope="row" class="text-muted fw-normal text-nowrap">SK Pendirian</th>

--- a/app/Views/profil_pt/index.php
+++ b/app/Views/profil_pt/index.php
@@ -41,8 +41,10 @@
                         <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
                             <div>
                                 <h2 class="display-6 mb-1"><?= esc($profilPT['nama_perguruan_tinggi']) ?></h2>
-                                <div class="text-muted small mb-1">Kode PT: <?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></div>
-                                <div class="text-muted small">Kepemilikan: <?= esc($profilPT['nama_status_milik'] ?? '-') ?></div>
+                                <div class="d-flex gap-4 small text-muted">
+                                    <div><span>Kode PT:</span> <?= esc($profilPT['kode_perguruan_tinggi'] ?? '-') ?></div>
+                                    <div><span>Kepemilikan:</span> <?= esc($profilPT['nama_status_milik'] ?? '-') ?></div>
+                                </div>
                             </div>
                             <span class="badge bg-success fs-6">Akreditasi <?= esc($profilPT['status_perguruan_tinggi'] ?? '-') ?></span>
                         </div>


### PR DESCRIPTION
## Deskripsi

Redesain halaman Profil Perguruan Tinggi dengan visual hierarchy yang jelas, mengikuti AdminLTE 4 + Bootstrap 5.3.

### Layout akhir

- **Hero card** \card-outline-primary\ — nama PT (display-6) + badge Akreditasi, info identitas + legalitas dalam \d-flex gap-4\
- **Kontak card** \card-info h-100\ — telepon/fax/email clickable/website clickable, icon fa-fw rata
- **Alamat card** \card-info h-100\ — alamat dalam paragraf natural, equal-height via \d-flex flex-column\ + \mt-auto\
- **Website:** prepend https:// otomatis di controller
- **Tanggal SK:** format Bahasa Indonesia via strtr()
- **No custom CSS, zero horizontal lines**

### Files changed

| File | Perubahan |
|------|-----------|
| app/Controllers/ProfilPT.php | prepend https://, tanggal Indonesia |
| app/Views/profil_pt/index.php | full rewrite — 3 tier layout |
| CHANGELOG.md | cleaned up, 1 final entry |
| DESIGN.md | sections 4.5 Hero card, 4.6 Detail info card |
| .memory/memory.yaml | 4 ADRs baru |

### Verification

- [x] \php -l\ passed on all files
- [x] \
pm run build\ passed
- [x] \php spark routes\ — route registered
- [x] \endor/bin/phpunit\ — 15/15 green