### PR TITLE
fix: correct DESIGN.md line count, validation example, and naming inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None yet._
 
 ### Changed
 
-- **Documentation shrinkage for model context:** `DESIGN.md` 1138→~350 lines (removed Bootstrap 5 boilerplate, kept project-specific patterns only); `CODING_STANDARDS.md` 537→~280 lines (trimmed general PHP knowledge); `OPEN_ISSUES.md` 295→~50 lines (archived 9 done Sprint 1 items to `archive/SPRINT1_ISSUES.md`)
+- **Documentation shrinkage for model context:** `DESIGN.md` 1138→473 lines (removed Bootstrap 5 boilerplate, kept project-specific patterns only); `CODING_STANDARDS.md` 537→287 lines (trimmed general PHP knowledge); `OPEN_ISSUES.md` 295→54 lines (archived 9 done Sprint 1 items to `archive/SPRINT1_ISSUES.md`)
 - **Documentation restructure:** `AGENTS.md` split into Golden Path (must-survive compression) + Reference sections; `CONTRIBUTING.md` deduplicated to human-focused content — lifecycle removed (delegated to AGENTS.md)
 - **Sidebar navigation:** added auto-detection of active page via `active` CSS class on current route
 - **Dashboard version:** replaced hardcoded `v0.1.0` with dynamic value from `config('AppVersion')->version`

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -89,8 +89,8 @@ Every POST form includes `<?= csrf_field() ?>` immediately after `<form>`.
 
 ```php
 if (! $this->validate([
-    'username' => 'required|valid_email',
-    'password' => 'required|min_length[6]',
+    'email' => 'required|valid_email',
+    'name'  => 'required',
 ])) {
     return redirect()->back()->withInput()->with('errors', $this->validator->getErrors());
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Copy `env` to `.env`, configure `baseURL`, `encryption.key`, `neofeeder.*`.
 
 ## Development Workflow
 
-Read `AGENTS.md` (Part A: Golden Path) for the full gate-based lifecycle.
+Read `AGENTS.md` (▸ Golden Path section) for the full gate-based lifecycle.
 This project follows: Plan → Execute → Docs & Commit → PR → Review → Merge & Cleanup.
 
 Every phase has a required gate output. Skip a gate → rollback to previous phase.


### PR DESCRIPTION
## Perubahan

3 minor fixes dari audit dokumentasi:

1. CHANGELOG.md: angka lines DESIGN.md diperbaiki dari ~350 ke 473
2. CODING_STANDARDS.md: contoh validation diganti field username valid_email menjadi email + name
3. CONTRIBUTING.md: referensi Part A: Golden Path diselaraskan dengan heading aktual AGENTS.md

Verification: 3 files, 4 insertions, 4 deletions. Docs-only.