### PR TITLE
fix: split multi-statement line in sidebar.php for php-cs-fixer

### DIFF
--- a/app/Views/layout/sidebar.php
+++ b/app/Views/layout/sidebar.php
@@ -7,7 +7,8 @@
 
         <div class="sidebar-wrapper">
             <!-- Sidebar Menu -->
-            <?php $currentUrl = (string) current_url(); $currentRoute = basename(parse_url($currentUrl, PHP_URL_PATH)); ?>
+            <?php $currentUrl = (string) current_url();
+            $currentRoute = basename(parse_url($currentUrl, PHP_URL_PATH)); ?>
             <nav class="mt-2">
                 <ul class="nav sidebar-menu flex-column" data-lte-toggle="treeview" role="menu">
                     <li class="nav-item">


### PR DESCRIPTION
## Summary

Fix the `php-cs-fixer` failure that breaks CI on `main`.

`app/Views/layout/sidebar.php:10` contained two statements on a single line:
`$currentUrl = (string) current_url(); $currentRoute = ...;`

Split onto two lines so `php-cs-fixer` (step "Check code style") passes. This unblocks PHPUnit which currently never runs because the style check fails first.

## Related issues

Fixes #13

## Checklist

- [x] `php -l` passes on all modified PHP files
- [x] `npm run build` succeeds and committed assets are up to date (no assets changed)
- [x] `php spark routes` shows correct new routes (no routes changed)
- [x] `vendor/bin/php-cs-fixer fix` passes (no style violations) — verified via CI
- [ ] `vendor/bin/phpunit` is green (if tests exist)
- [x] No debug code: `dd()`, `var_dump()`, `console.log()`, `print_r()`, `exit()`
- [x] All user inputs validated server-side (no logic changed)
- [x] All POST forms include `csrf_field()` (no logic changed)
- [x] All HTML output uses `esc()` (no logic changed)
- [x] No unrelated files changed
- [x] CHANGELOG updated if this is a user-facing change (not user-facing — code style only)

## Screenshot (if applicable)

Not applicable — no UI change.

## Notes for reviewers

View-only change, no behaviour difference. CI will now run PHPUnit after the style check passes.
