### PR TITLE
ci: harden workflow with least-privilege, concurrency, and timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Hardens the CI workflow with least-privilege permissions, concurrency control, and a job timeout.

## Changes
- **ENH-005** (#27): add `permissions: contents: read` so the Actions token is read-only
- **ENH-006** (#28): add `concurrency` group keyed on workflow + ref with `cancel-in-progress: true` so re-pushes cancel stale runs
- **ENH-007** (#29): add `timeout-minutes: 30` to the `build` job

## Verification
- CI itself will validate the workflow YAML on the PR run
- No PHP/npm code changed

## Related issues
- Fixes #27
- Fixes #28
- Fixes #29
