### PR TITLE
chore: add Dependabot configuration for composer, npm, and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to keep Composer, npm, and GitHub Actions dependencies up to date.

## Changes
- **ENH-009** (#24): new `.github/dependabot.yml` with three `package-ecosystem` entries (`composer`, `npm`, `github-actions`), each `directory: "/"` and weekly schedule

## Verification
- Format follows the official Dependabot schema
- No code changed

## Related issues
- Fixes #24
