### PR TITLE
docs: fix env documentation and remove API endpoint from repo files

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,9 +189,10 @@ Key `.env` variables used by the application:
 |----------|------|---------|---------|
 | `app.baseURL` | string | CI4 Router | Base URL for `base_url()` helper |
 | `encryption.key` | hex string | CI4 Encryption Service | Cookie encryption (32-byte hex) |
-| `neofeeder.api_url` | string | `Config/NeoFeeder.php` | Neo Feeder API base URL |
-| `neofeeder.timeout` | int | `Config/NeoFeeder.php` | HTTP request timeout (seconds) |
-| `neofeeder.ttl` | int | `Config/NeoFeeder.php` | Token cache TTL (seconds) |
+| `neofeeder.apiBaseUrl` | string | `Config/NeoFeeder.php` | Neo Feeder API base URL (required) |
+| `neofeeder.connectionTimeout` | int | `Config/NeoFeeder.php` | Connection timeout (seconds) |
+| `neofeeder.requestTimeout` | int | `Config/NeoFeeder.php` | HTTP request timeout (seconds) |
+| `neofeeder.validationTTL` | int | `Config/NeoFeeder.php` | Token validation cache TTL (seconds) |
 
 Set these in `.env` (copy from `env` template). Never commit `.env`.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ BASE/
 
 ## Neo Feeder API
 
-Endpoint: `https://neofeeder.stiem-bongaya.ac.id/ws/live2.php`
+The API base URL is configured via `neofeeder.apiBaseUrl` in `.env` (see the `env` template).
 
 ### Authentication (GetToken)
 

--- a/app/Config/NeoFeeder.php
+++ b/app/Config/NeoFeeder.php
@@ -14,9 +14,10 @@ class NeoFeeder extends BaseConfig
      * The base URL for the Neo Feeder Web Service API endpoint.
      * All API requests (GetToken, GetProfilPT, etc.) are sent to this URL.
      *
-     * Override via .env: neofeeder.apiBaseUrl
+     * Required — must be set via .env: neofeeder.apiBaseUrl
+     * No default is provided to prevent leaking a deployment-specific endpoint.
      */
-    public string $apiBaseUrl = 'https://neofeeder.stiem-bongaya.ac.id/ws/live2.php';
+    public string $apiBaseUrl = '';
 
     /**
      * --------------------------------------------------------------------------

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -218,3 +218,14 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Actual Fix:** Set `delete_branch_on_merge=true` via `gh api -X PATCH` on the repo so GitHub auto-deletes head branches on merge.
 - **Actual Implemented:** Set `delete_branch_on_merge=true` via `gh api -X PATCH` on the repo (F1).
 - **Changes:** Head branches are auto-deleted on merge; stale remote branches no longer accumulate.
+
+### ENH-012 — Local php-cs-fixer reports CRLF false positives on Windows
+- **Status:** `recorded`
+- **Issue:** `—`
+- **Recorded:** 2026-08-02
+- **Implemented:** `—`
+- **Problem:** Running `php-cs-fixer fix --dry-run` locally on Windows flags all PHP files (29 files) even though their content already conforms to the configured rules. Impact: the local dev cannot use the dry-run diff as a real signal, since every file is reported regardless of actual style violations. CI is unaffected (Linux checks out LF and passes), so this is purely a local-developer experience issue.
+- **Possible Fix:** Option A (full): set `.editorconfig` `end_of_line = lf`, set `.gitattributes` to `* text=auto eol=lf`, run `git add --renormalize .` and re-checkout so Windows always checks out LF. Trade-off: produces a noisy diff touching every PHP file. Option B (minimal): change `.editorconfig` `end_of_line` to `lf` so editors stop writing CRLF, and document in CONTRIBUTING that Windows devs should set `git config --global core.autocrlf false`. Old CRLF files are still flagged once, but no new ones appear.
+- **Actual Fix:** `—`
+- **Actual Implemented:** `—`
+- **Changes:** `—`

--- a/env
+++ b/env
@@ -56,6 +56,20 @@
 # encryption.key =
 
 #--------------------------------------------------------------------
+# NEO FEEDER
+#--------------------------------------------------------------------
+
+# Base URL of the Neo Feeder Web Service API endpoint.
+# Required — no default is provided; API requests fail if this is empty.
+# neofeeder.apiBaseUrl =
+# Maximum seconds to wait for a connection to the API server.
+# neofeeder.connectionTimeout = 10
+# Maximum seconds to wait for a complete API request (including connection).
+# neofeeder.requestTimeout = 30
+# Cache TTL (seconds) for token validation results.
+# neofeeder.validationTTL = 300
+
+#--------------------------------------------------------------------
 # SESSION
 #--------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fix documentation/config inconsistencies and remove the deployment-specific Neo Feeder API endpoint from tracked files.

## Changes

1. **ARCHITECTURE.md** — Correct the environment variable table to match the actual `app/Config/NeoFeeder.php` properties: `neofeeder.apiBaseUrl` (required), `neofeeder.connectionTimeout`, `neofeeder.requestTimeout`, `neofeeder.validationTTL` (previously listed non-existent keys `api_url`, `timeout`, `ttl`). Closes DOC-001.
2. **env** — Add a `NEO FEEDER` section documenting all four overridable variables with commented defaults. Previously the template had no `neofeeder.*` entries even though README/CONTRIBUTING instruct setting them. Closes DOC-002.
3. **app/Config/NeoFeeder.php** — Empty the `apiBaseUrl` default (`''`); the endpoint must now be set via `.env`. Prevents leaking a deployment-specific endpoint in the public repo.
4. **README.md** — Remove the hardcoded endpoint line (`neofeeder.stiem-bongaya.ac.id`), point to the `neofeeder.apiBaseUrl` env var instead.

## Related issues

- Closes #25 (DOC-001)
- Closes #26 (DOC-002)

## Checklist

- [x] Changes verified locally (phpunit 15 tests / 32 assertions, composer validate)
- [x] CI expected green (Linux LF checkout unaffected by local CRLF note)
- [x] Local `.env` retains the endpoint, app behavior unchanged
