### PR TITLE
refactor: rename BASE to Backbone for Academic Services & Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BASE (Bongaya Advanced Services Engine)
+# BASE (Backbone for Academic Services & Education)
 
 [![CI](https://github.com/ffooll-bit/BASE/actions/workflows/ci.yml/badge.svg)](https://github.com/ffooll-bit/BASE/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -6,9 +6,9 @@
 
 BASE is a web application built on CodeIgniter 4. Its primary purpose is to act as a **Web Service Client** for **Neo Feeder** — the application that synchronizes data with the PDDIKTI database.
 
-Currently, BASE acts as a **client** of the Neo Feeder web service. Going forward, the application will be developed to integrate with other applications within STIEM Bongaya.
+Currently, BASE acts as a **client** of the Neo Feeder web service. Going forward, the application will be developed to integrate with other academic applications.
 
-The name **BASE** (Bongaya Advanced Services Engine) reflects that the application will serve as the **foundation** for integrating other systems.
+The name **BASE** (Backbone for Academic Services & Education) reflects that the application will serve as the **foundation** for integrating other systems.
 
 ## Development Status
 

--- a/app/Views/layout/header.php
+++ b/app/Views/layout/header.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?= esc($title ?? 'BASE - Bongaya Advanced Services Engine') ?></title>
+    <title><?= esc($title ?? 'BASE - Backbone for Academic Services & Education') ?></title>
     <!-- Google Font: Source Sans 3 (AdminLTE 4) -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+3:300,400,400i,600,700&display=fallback">
     <!-- Font Awesome -->

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ffooll-bit/base",
-    "description": "Bongaya Advanced Services Engine - Neo Feeder Web Service Client",
+    "description": "Backbone for Academic Services & Education - Neo Feeder Web Service Client",
     "license": "MIT",
     "type": "project",
     "homepage": "https://github.com/ffooll-bit/BASE",

--- a/tests/unit/Libraries/NeoFeederTest.php
+++ b/tests/unit/Libraries/NeoFeederTest.php
@@ -76,7 +76,7 @@ class NeoFeederTest extends CIUnitTestCase
     {
         $responseBody = json_encode([
             'error_code' => 0,
-            'data'       => ['nama_pt' => 'STIEM Bongaya'],
+            'data'       => ['kode_pt' => '123456'],
         ]);
 
         $response = $this->createStub(ResponseInterface::class);
@@ -89,6 +89,6 @@ class NeoFeederTest extends CIUnitTestCase
         $result    = $neoFeeder->getProfilPT('token-abc');
 
         $this->assertSame(0, $result['error_code']);
-        $this->assertSame('STIEM Bongaya', $result['data']['nama_pt']);
+        $this->assertSame('123456', $result['data']['kode_pt']);
     }
 }


### PR DESCRIPTION
Renames the BASE expansion from Bongaya Advanced Services Engine to Backbone for Academic Services & Education so the name does not reference any institution.

- README: title, intro paragraph, name explanation
- layout header: default page title
- composer.json: description
- NeoFeederTest: replace institution-specific test data (nama_pt) with neutral kode_pt

Closes nothing (naming decision, not a tracked issue).