### PR TITLE
chore: align repository to workflow adoption standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Check line endings
+        run: |
+          if grep -rlP '\r$' --include="*.md" .; then
+            echo "::error::CRLF line endings found in markdown files"
+            exit 1
+          fi
+
+      - name: Check no BOM
+        run: |
+          if grep -rlU $'\xEF\xBB\xBF' --include="*.md" .; then
+            echo "::error::UTF-8 BOM found in markdown files"
+            exit 1
+          fi
+
       - name: Setup PHP 8.2
         uses: shivammathur/setup-php@v2
         with:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ BASE is a CodeIgniter 4 web application that serves as a Web Service Client for 
 | Identity Provider | Neo Feeder WS API | — | Authentication & token validation |
 | UI Template | AdminLTE 4 | ^4.0 | Dashboard layout, sidebar, navbar |
 | CSS Framework | Bootstrap 5 | 5.3.x | Components, grid, utilities (transitive via AdminLTE 4) |
-| Icons | Font Awesome 7 | ^7.0 | UI icons |
+| Icons | Font Awesome 7 | ^7.3 | UI icons |
 | JS Runtime | Vanilla JavaScript | — | AdminLTE 4 native, no jQuery |
 | Session | CI4 FileHandler | — | Auth state storage |
 | HTTP Client | CI4 CURLRequest | — | Neo Feeder API communication |
@@ -70,6 +70,7 @@ Filter ordering: **Required before** → **Global before** → Route → Control
 | POST | `/login` | `Login::attemptLogin` | Whitelisted | Enabled |
 | POST | `/logout` | `Login::logout` | Protected | Enabled |
 | GET | `/dashboard` | `Dashboard::index` | Protected | — |
+| GET | `/profil-pt` | `ProfilPT::index` | Protected | — |
 
 ---
 
@@ -78,9 +79,10 @@ Filter ordering: **Required before** → **Global before** → Route → Control
 | Class | File | Responsibility | Dependencies |
 |-------|------|---------------|--------------|
 | `BaseController` | `Controllers/BaseController.php` | Shared controller setup (session, helpers) | — |
-| `Home` | `Controllers/Home.php` | Welcome / landing page (pre-auth) | — |
+| `Home` | `Controllers/Home.php` | Root redirect: `/login` (anonymous) or `/dashboard` (authenticated) | `Auth` service |
 | `Login` | `Controllers/Login.php` | Login form, login attempt, logout | `Auth` service |
 | `Dashboard` | `Controllers/Dashboard.php` | Protected landing page | `Auth` service, 4 views |
+| `ProfilPT` | `Controllers/ProfilPT.php` | PT profile page: formats `GetProfilPT` data (SK date to Indonesian, website URL normalization) | `Auth`, `NeoFeeder` services, view `profil_pt/index` |
 | `AuthFilter` | `Filters/AuthFilter.php` | Route protection middleware | `Auth` service, CI4 Session |
 | `Auth` | `Libraries/Auth.php` | Auth logic: login, logout, validate, caching | `NeoFeeder`, `Session`, `EncrypterInterface` |
 | `NeoFeeder` | `Libraries/NeoFeeder.php` | HTTP layer for Neo Feeder API | `NeoFeederConfig`, `CURLRequest` |
@@ -226,10 +228,10 @@ All assets are pre-compiled (no bundler). The build script copies files from `no
 ```
 app/
 ├── Config/          # NeoFeeder, Filters, Routes, Services
-├── Controllers/     # Login, Dashboard, Home, BaseController
+├── Controllers/     # Login, Dashboard, ProfilPT, Home, BaseController
 ├── Filters/         # AuthFilter (route protection)
 ├── Libraries/       # Auth, NeoFeeder (service layer)
-└── Views/           # login/ (standalone), layout/ (header,sidebar,footer), dashboard/
+└── Views/           # login/ (standalone), layout/ (header,sidebar,footer), dashboard/, profil_pt/
 public/              # index.php + built assets
 ├── adminlte/        # adminlte.min.css, adminlte.min.js
 ├── bootstrap/       # bootstrap.min.css, bootstrap.bundle.min.js


### PR DESCRIPTION
## Summary

Aligns the repository to the workflow adoption standard defined in the project policies.

## Changes

- **Guardrails:**
  - .editorconfig: end_of_line = lf (was crlf) — enforces LF per Boundaries policy
  - .gitattributes: * text=auto eol=lf — ensures LF normalization on checkout
  - .github/workflows/ci.yml: Added line-ending and BOM check steps from template

- **Repository Settings:**
  - Enabled all three merge methods (merge, ebase, squash) per Repository-Protection policy
  - Merge method per PR decided by merge-strategy policy (non-collaborator→squash, 1 collaborator→rebase, 2+→merge commit)

- **Branch Hygiene:**
  - Deleted stale remote branches: docs/mark-enh008-implemented, efactor/rename-base-backbone
  - Deleted stale local branch: efactor/rename-base-backbone

- **Documentation:**
  - Updated ARCHITECTURE.md: Added ProfilPT route, corrected Font Awesome version, updated controller/view listings

## Verification

- No CRLF line endings in markdown files
- No UTF-8 BOM in markdown files
- CI includes required line-ending/BOM checks
- All three merge methods enabled

Fixes ENH-012 (php-cs-fixer CRLF false positives) via .editorconfig fix.