### PR TITLE
docs: CHANGELOG entry for admin-lte 4.8.4 Dependabot bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ _None yet._
 - **Dashboard version:** replaced hardcoded `v0.1.0` with dynamic value from `config('AppVersion')->version`
 - **Release process:** added step to update `app/Config/AppVersion.php` when releasing a new version
 - **Profil PT page:** redesigned layout with visual hierarchy — hero card `card-outline-primary` (name in `display-6` + accreditation badge, identity & legalitas info in `d-flex gap-4`), two `card-info h-100` cards side by side (Contact with clickable links + Address), `fa-fw` for aligned icons, equal-height via `d-flex flex-column` + `mt-auto`, `https://` prepended to website URL, Indonesian date format via `strtr()`, max width via `col-xxl-10`
+- **Dependencies:** bumped `admin-lte` from 4.1.0 to 4.8.4 (AdminLTE 4.x line — no breaking changes, backward-compatible HTML/CSS)
 
 ### Fixed
 


### PR DESCRIPTION
Adds a user-facing CHANGELOG entry under [Unreleased] > Changed for the admin-lte 4.1.0 to 4.8.4 bump (Dependabot PR #45).

The php-cs-fixer bump (PR #44) is dev-only and omitted per the CHANGELOG agent instructions (skip chore/test unless user-facing).