### PR TITLE
feat: add read-only Neo Feeder menu pages for graduation-flow verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _None yet._
 
 - **Profil PT page:** dedicated page (`/profil-pt`) displaying institution profile data from NeoFeeder API — identity, contact, address, and legalitas in two AdminLTE cards; sidebar navigation item added
 - **Route:** `GET /profil-pt` → `ProfilPT::index` with auth+csrf filters
+- **Neo Feeder menu pages:** read-only pages for `Daftar Mahasiswa` (`/mahasiswa`), `Aktivitas Kuliah Mahasiswa` (`/aktivitas-kuliah`), and `Daftar Mahasiswa Lulus/Dropout` (`/mahasiswa-lulus-do`). Each calls the corresponding NeoFeeder `Get` API through the service layer with `filter`/`limit`/`offset` pagination — a direct browsing surface for the graduation-flow verification (ENH-014) — #51
 
 ### Changed
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -17,3 +17,6 @@ $routes->post('login', 'Login::attemptLogin');
 $routes->post('logout', 'Login::logout');
 $routes->get('dashboard', 'Dashboard::index');
 $routes->get('profil-pt', 'ProfilPT::index');
+$routes->get('mahasiswa', 'Mahasiswa::index');
+$routes->get('aktivitas-kuliah', 'AktivitasKuliah::index');
+$routes->get('mahasiswa-lulus-do', 'MahasiswaLulusDo::index');

--- a/app/Controllers/AktivitasKuliah.php
+++ b/app/Controllers/AktivitasKuliah.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Controllers;
+
+class AktivitasKuliah extends BaseController
+{
+    private const ALLOWED_FILTERS = ['nim', 'nama_mahasiswa', 'angkatan', 'id_semester'];
+    private const PAGE_SIZE = 20;
+
+    public function index()
+    {
+        $username = service('auth')->getCurrentUser();
+        $rows = null;
+        $error = null;
+        $filters = $this->collectFilters(self::ALLOWED_FILTERS);
+        $page = max(1, (int) $this->request->getGet('page'));
+        $options = $filters;
+        $options['limit'] = self::PAGE_SIZE;
+        $options['offset'] = ($page - 1) * self::PAGE_SIZE;
+
+        $token = session('auth.token');
+        if ($token !== null) {
+            $response = service('neoFeeder')->getAktivitasKuliahMahasiswa($token, $options);
+            if (($response['error_code'] ?? -1) === 0 && isset($response['data'])) {
+                $rows = $response['data'];
+            } else {
+                $error = $response['error_msg'] ?? 'Gagal memuat data aktivitas kuliah mahasiswa.';
+            }
+        }
+
+        return view('layout/header', ['username' => $username, 'title' => 'Aktivitas Kuliah Mahasiswa'])
+            . view('layout/sidebar', ['username' => $username])
+            . view('aktivitas_kuliah/index', [
+                'username' => $username,
+                'rows'     => $rows,
+                'error'    => $error,
+                'filters'  => $filters,
+                'page'     => $page,
+                'pageSize' => self::PAGE_SIZE,
+            ])
+            . view('layout/footer');
+    }
+}

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -44,6 +44,26 @@ abstract class BaseController extends Controller
     // protected $session;
 
     /**
+     * Collects non-empty filter values from the request query string.
+     *
+     * @param list<string> $allowed Allowed filter field names.
+     *
+     * @return array<string, string> The non-empty filter values.
+     */
+    protected function collectFilters(array $allowed): array
+    {
+        $filters = [];
+        foreach ($allowed as $key) {
+            $value = $this->request->getGet($key);
+            if ($value !== null && $value !== '') {
+                $filters[$key] = $value;
+            }
+        }
+
+        return $filters;
+    }
+
+    /**
      * @return void
      */
     public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)

--- a/app/Controllers/Mahasiswa.php
+++ b/app/Controllers/Mahasiswa.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Controllers;
+
+class Mahasiswa extends BaseController
+{
+    private const ALLOWED_FILTERS = ['nim', 'nipd', 'nama_mahasiswa', 'angkatan'];
+    private const PAGE_SIZE = 20;
+
+    public function index()
+    {
+        $username = service('auth')->getCurrentUser();
+        $rows = null;
+        $error = null;
+        $filters = $this->collectFilters(self::ALLOWED_FILTERS);
+        $page = max(1, (int) $this->request->getGet('page'));
+        $options = $filters;
+        $options['limit'] = self::PAGE_SIZE;
+        $options['offset'] = ($page - 1) * self::PAGE_SIZE;
+
+        $token = session('auth.token');
+        if ($token !== null) {
+            $response = service('neoFeeder')->getListMahasiswa($token, $options);
+            if (($response['error_code'] ?? -1) === 0 && isset($response['data'])) {
+                $rows = $response['data'];
+            } else {
+                $error = $response['error_msg'] ?? 'Gagal memuat data mahasiswa.';
+            }
+        }
+
+        return view('layout/header', ['username' => $username, 'title' => 'Daftar Mahasiswa'])
+            . view('layout/sidebar', ['username' => $username])
+            . view('mahasiswa/index', [
+                'username' => $username,
+                'rows'     => $rows,
+                'error'    => $error,
+                'filters'  => $filters,
+                'page'     => $page,
+                'pageSize' => self::PAGE_SIZE,
+            ])
+            . view('layout/footer');
+    }
+}

--- a/app/Controllers/MahasiswaLulusDo.php
+++ b/app/Controllers/MahasiswaLulusDo.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Controllers;
+
+class MahasiswaLulusDo extends BaseController
+{
+    private const ALLOWED_FILTERS = ['nim', 'nama_mahasiswa', 'id_jenis_keluar'];
+    private const PAGE_SIZE = 20;
+
+    public function index()
+    {
+        $username = service('auth')->getCurrentUser();
+        $rows = null;
+        $error = null;
+        $filters = $this->collectFilters(self::ALLOWED_FILTERS);
+        $page = max(1, (int) $this->request->getGet('page'));
+        $options = $filters;
+        $options['limit'] = self::PAGE_SIZE;
+        $options['offset'] = ($page - 1) * self::PAGE_SIZE;
+
+        $token = session('auth.token');
+        if ($token !== null) {
+            $response = service('neoFeeder')->getListMahasiswaLulusDO($token, $options);
+            if (($response['error_code'] ?? -1) === 0 && isset($response['data'])) {
+                $rows = $response['data'];
+            } else {
+                $error = $response['error_msg'] ?? 'Gagal memuat data mahasiswa lulus/dropout.';
+            }
+        }
+
+        return view('layout/header', ['username' => $username, 'title' => 'Daftar Mahasiswa Lulus / Dropout'])
+            . view('layout/sidebar', ['username' => $username])
+            . view('mahasiswa_lulus_do/index', [
+                'username' => $username,
+                'rows'     => $rows,
+                'error'    => $error,
+                'filters'  => $filters,
+                'page'     => $page,
+                'pageSize' => self::PAGE_SIZE,
+            ])
+            . view('layout/footer');
+    }
+}

--- a/app/Libraries/NeoFeeder.php
+++ b/app/Libraries/NeoFeeder.php
@@ -131,6 +131,66 @@ class NeoFeeder
     }
 
     /**
+     * Sends a list-style request (Get action with optional filter/order/limit/offset).
+     *
+     * @param string $act     The API action name.
+     * @param string $token   The authentication token.
+     * @param array  $options Optional filter/order/limit/offset overrides.
+     *
+     * @return array The decoded API response on success, or a structured error array.
+     */
+    private function sendListRequest(string $act, string $token, array $options = []): array
+    {
+        $payload = ['act' => $act, 'token' => $token];
+        foreach (['filter', 'order', 'limit', 'offset'] as $key) {
+            if (array_key_exists($key, $options)) {
+                $payload[$key] = $options[$key];
+            }
+        }
+
+        return $this->sendRequest($payload);
+    }
+
+    /**
+     * Retrieves the list of students (Daftar Mahasiswa) from the Neo Feeder API.
+     *
+     * @param string $token   The authentication token obtained from getToken().
+     * @param array  $options Optional filter/order/limit/offset overrides.
+     *
+     * @return array The decoded API response on success, or a structured error array.
+     */
+    public function getListMahasiswa(string $token, array $options = []): array
+    {
+        return $this->sendListRequest('GetListMahasiswa', $token, $options);
+    }
+
+    /**
+     * Retrieves the student course activities (Aktivitas Kuliah Mahasiswa) from the Neo Feeder API.
+     *
+     * @param string $token   The authentication token obtained from getToken().
+     * @param array  $options Optional filter/order/limit/offset overrides.
+     *
+     * @return array The decoded API response on success, or a structured error array.
+     */
+    public function getAktivitasKuliahMahasiswa(string $token, array $options = []): array
+    {
+        return $this->sendListRequest('GetAktivitasKuliahMahasiswa', $token, $options);
+    }
+
+    /**
+     * Retrieves the graduated/dropped-out student list (Daftar Mahasiswa Lulus/DO) from the Neo Feeder API.
+     *
+     * @param string $token   The authentication token obtained from getToken().
+     * @param array  $options Optional filter/order/limit/offset overrides.
+     *
+     * @return array The decoded API response on success, or a structured error array.
+     */
+    public function getListMahasiswaLulusDO(string $token, array $options = []): array
+    {
+        return $this->sendListRequest('GetListMahasiswaLulusDO', $token, $options);
+    }
+
+    /**
      * Encodes a payload as JSON, returning a validated string.
      *
      * @param array $payload The payload to encode.

--- a/app/Views/aktivitas_kuliah/index.php
+++ b/app/Views/aktivitas_kuliah/index.php
@@ -1,0 +1,85 @@
+<div class="app-content-header">
+    <div class="container-fluid">
+        <div class="row mb-2">
+            <div class="col-sm-6">
+                <h3 class="m-0">Aktivitas Kuliah Mahasiswa</h3>
+            </div>
+            <div class="col-sm-6">
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb float-sm-end">
+                        <li class="breadcrumb-item"><a href="<?= base_url('dashboard') ?>">Home</a></li>
+                        <li class="breadcrumb-item active">Aktivitas Kuliah Mahasiswa</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="app-content">
+    <div class="container-fluid">
+
+        <?php if ($error): ?>
+            <div class="alert alert-danger alert-dismissible">
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                <i class="fas fa-times-circle"></i> <?= esc($error) ?>
+            </div>
+        <?php endif; ?>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <form method="get" class="row g-2">
+                    <div class="col-md-3">
+                        <input type="text" class="form-control" name="nim" placeholder="NIM" value="<?= esc($filters['nim'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-3">
+                        <input type="text" class="form-control" name="nama_mahasiswa" placeholder="Nama Mahasiswa" value="<?= esc($filters['nama_mahasiswa'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-3">
+                        <input type="text" class="form-control" name="angkatan" placeholder="Angkatan" value="<?= esc($filters['angkatan'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-2">
+                        <input type="text" class="form-control" name="id_semester" placeholder="ID Semester" value="<?= esc($filters['id_semester'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-1">
+                        <button type="submit" class="btn btn-primary w-100">Cari</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <?php if ($rows === null && !$error): ?>
+            <div class="alert alert-info">
+                <i class="fas fa-info-circle"></i> Masukkan filter untuk menampilkan data aktivitas kuliah mahasiswa.
+            </div>
+        <?php elseif ($rows !== null): ?>
+            <div class="card">
+                <div class="card-body table-responsive">
+                    <?php if (empty($rows)): ?>
+                        <div class="alert alert-warning mb-0">Tidak ada data yang cocok dengan filter.</div>
+                    <?php else: ?>
+                        <table class="table table-bordered table-striped">
+                            <thead>
+                                <tr>
+                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($col) ?></th><?php endforeach; ?>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($rows as $row): ?>
+                                    <tr><?php foreach ($row as $cell): ?><td><?= esc($cell) ?></td><?php endforeach; ?></tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    <?php endif; ?>
+                </div>
+                <div class="card-footer d-flex justify-content-between align-items-center">
+                    <?php $prev = http_build_query(array_merge($filters, ['page' => max(1, $page - 1)])); ?>
+                    <a href="?<?= esc($prev, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= $page <= 1 ? 'disabled' : '' ?>">Sebelumnya</a>
+                    <span>Halaman <?= esc($page) ?></span>
+                    <?php $next = http_build_query(array_merge($filters, ['page' => $page + 1])); ?>
+                    <a href="?<?= esc($next, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= count($rows) < $pageSize ? 'disabled' : '' ?>">Berikutnya</a>
+                </div>
+            </div>
+        <?php endif; ?>
+
+    </div>
+</div>

--- a/app/Views/layout/sidebar.php
+++ b/app/Views/layout/sidebar.php
@@ -23,6 +23,24 @@
                             <p>Profil Perguruan Tinggi</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="<?= base_url('mahasiswa') ?>" class="nav-link <?= $currentRoute === 'mahasiswa' ? 'active' : '' ?>">
+                            <i class="nav-icon fas fa-user-graduate"></i>
+                            <p>Mahasiswa</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="<?= base_url('aktivitas-kuliah') ?>" class="nav-link <?= $currentRoute === 'aktivitas-kuliah' ? 'active' : '' ?>">
+                            <i class="nav-icon fas fa-chalkboard-teacher"></i>
+                            <p>Aktivitas Kuliah</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="<?= base_url('mahasiswa-lulus-do') ?>" class="nav-link <?= $currentRoute === 'mahasiswa-lulus-do' ? 'active' : '' ?>">
+                            <i class="nav-icon fas fa-user-check"></i>
+                            <p>Mahasiswa Lulus / DO</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/app/Views/mahasiswa/index.php
+++ b/app/Views/mahasiswa/index.php
@@ -1,0 +1,85 @@
+<div class="app-content-header">
+    <div class="container-fluid">
+        <div class="row mb-2">
+            <div class="col-sm-6">
+                <h3 class="m-0">Daftar Mahasiswa</h3>
+            </div>
+            <div class="col-sm-6">
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb float-sm-end">
+                        <li class="breadcrumb-item"><a href="<?= base_url('dashboard') ?>">Home</a></li>
+                        <li class="breadcrumb-item active">Daftar Mahasiswa</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="app-content">
+    <div class="container-fluid">
+
+        <?php if ($error): ?>
+            <div class="alert alert-danger alert-dismissible">
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                <i class="fas fa-times-circle"></i> <?= esc($error) ?>
+            </div>
+        <?php endif; ?>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <form method="get" class="row g-2">
+                    <div class="col-md-3">
+                        <input type="text" class="form-control" name="nim" placeholder="NIM" value="<?= esc($filters['nim'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-3">
+                        <input type="text" class="form-control" name="nipd" placeholder="NIPD" value="<?= esc($filters['nipd'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-3">
+                        <input type="text" class="form-control" name="nama_mahasiswa" placeholder="Nama Mahasiswa" value="<?= esc($filters['nama_mahasiswa'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-2">
+                        <input type="text" class="form-control" name="angkatan" placeholder="Angkatan" value="<?= esc($filters['angkatan'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-1">
+                        <button type="submit" class="btn btn-primary w-100">Cari</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <?php if ($rows === null && !$error): ?>
+            <div class="alert alert-info">
+                <i class="fas fa-info-circle"></i> Masukkan filter untuk menampilkan data mahasiswa.
+            </div>
+        <?php elseif ($rows !== null): ?>
+            <div class="card">
+                <div class="card-body table-responsive">
+                    <?php if (empty($rows)): ?>
+                        <div class="alert alert-warning mb-0">Tidak ada data yang cocok dengan filter.</div>
+                    <?php else: ?>
+                        <table class="table table-bordered table-striped">
+                            <thead>
+                                <tr>
+                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($col) ?></th><?php endforeach; ?>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($rows as $row): ?>
+                                    <tr><?php foreach ($row as $cell): ?><td><?= esc($cell) ?></td><?php endforeach; ?></tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    <?php endif; ?>
+                </div>
+                <div class="card-footer d-flex justify-content-between align-items-center">
+                    <?php $prev = http_build_query(array_merge($filters, ['page' => max(1, $page - 1)])); ?>
+                    <a href="?<?= esc($prev, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= $page <= 1 ? 'disabled' : '' ?>">Sebelumnya</a>
+                    <span>Halaman <?= esc($page) ?></span>
+                    <?php $next = http_build_query(array_merge($filters, ['page' => $page + 1])); ?>
+                    <a href="?<?= esc($next, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= count($rows) < $pageSize ? 'disabled' : '' ?>">Berikutnya</a>
+                </div>
+            </div>
+        <?php endif; ?>
+
+    </div>
+</div>

--- a/app/Views/mahasiswa_lulus_do/index.php
+++ b/app/Views/mahasiswa_lulus_do/index.php
@@ -1,0 +1,82 @@
+<div class="app-content-header">
+    <div class="container-fluid">
+        <div class="row mb-2">
+            <div class="col-sm-6">
+                <h3 class="m-0">Daftar Mahasiswa Lulus / Dropout</h3>
+            </div>
+            <div class="col-sm-6">
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb float-sm-end">
+                        <li class="breadcrumb-item"><a href="<?= base_url('dashboard') ?>">Home</a></li>
+                        <li class="breadcrumb-item active">Mahasiswa Lulus / DO</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="app-content">
+    <div class="container-fluid">
+
+        <?php if ($error): ?>
+            <div class="alert alert-danger alert-dismissible">
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                <i class="fas fa-times-circle"></i> <?= esc($error) ?>
+            </div>
+        <?php endif; ?>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <form method="get" class="row g-2">
+                    <div class="col-md-3">
+                        <input type="text" class="form-control" name="nim" placeholder="NIM" value="<?= esc($filters['nim'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-4">
+                        <input type="text" class="form-control" name="nama_mahasiswa" placeholder="Nama Mahasiswa" value="<?= esc($filters['nama_mahasiswa'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-3">
+                        <input type="text" class="form-control" name="id_jenis_keluar" placeholder="ID Jenis Keluar" value="<?= esc($filters['id_jenis_keluar'] ?? '') ?>">
+                    </div>
+                    <div class="col-md-2">
+                        <button type="submit" class="btn btn-primary w-100">Cari</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <?php if ($rows === null && !$error): ?>
+            <div class="alert alert-info">
+                <i class="fas fa-info-circle"></i> Masukkan filter untuk menampilkan data mahasiswa lulus/dropout.
+            </div>
+        <?php elseif ($rows !== null): ?>
+            <div class="card">
+                <div class="card-body table-responsive">
+                    <?php if (empty($rows)): ?>
+                        <div class="alert alert-warning mb-0">Tidak ada data yang cocok dengan filter.</div>
+                    <?php else: ?>
+                        <table class="table table-bordered table-striped">
+                            <thead>
+                                <tr>
+                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($col) ?></th><?php endforeach; ?>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($rows as $row): ?>
+                                    <tr><?php foreach ($row as $cell): ?><td><?= esc($cell) ?></td><?php endforeach; ?></tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    <?php endif; ?>
+                </div>
+                <div class="card-footer d-flex justify-content-between align-items-center">
+                    <?php $prev = http_build_query(array_merge($filters, ['page' => max(1, $page - 1)])); ?>
+                    <a href="?<?= esc($prev, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= $page <= 1 ? 'disabled' : '' ?>">Sebelumnya</a>
+                    <span>Halaman <?= esc($page) ?></span>
+                    <?php $next = http_build_query(array_merge($filters, ['page' => $page + 1])); ?>
+                    <a href="?<?= esc($next, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= count($rows) < $pageSize ? 'disabled' : '' ?>">Berikutnya</a>
+                </div>
+            </div>
+        <?php endif; ?>
+
+    </div>
+</div>

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -253,10 +253,10 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** `—`
 
 ### ENH-014 — Standalone Neo Feeder menu pages used by the graduation flow
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #51
-- **Recorded:** 2026-08-27
-- **Implemented:** `—`
+- **Recorded:** 2026-08-25
+- **Implemented:** 2026-08-27
 - **Problem:** The graduation flow (ENH-013) needs access to several Neo Feeder menus — *Daftar Mahasiswa*, *Aktifitas Kuliah Mahasiswa*, *Daftar Mahasiswa Lulus/Dropout*. BASE has no standalone menu pages mirroring Neo Feeder navigation, so the admin must switch to Neo Feeder for each verification/input step.
 - **Possible Fix:** Add standalone menu pages in BASE mapping the Neo Feeder menus used in the ENH-013 flow: *Daftar Mahasiswa*, *Aktifitas Kuliah Mahasiswa*, *Daftar Mahasiswa Lulus/Dropout* (and any other menus that surface during ENH-013 implementation). Each page calls the NeoFeeder API through the existing service layer (`Libraries/NeoFeeder`). These become the navigation surface for the ENH-013 wizard.
 - **Actual Fix:** Feasible — the NeoFeeder WS API exposes GetListMahasiswa, GetAktivitasKuliahMahasiswa, GetListMahasiswaLulusDO. Add read-only pages in BASE (controller + view + route) calling the `Libraries/NeoFeeder` layer extended with these three Get methods. These become the navigation surface for the ENH-013 wizard.

--- a/tests/unit/Libraries/NeoFeederTest.php
+++ b/tests/unit/Libraries/NeoFeederTest.php
@@ -91,4 +91,64 @@ class NeoFeederTest extends CIUnitTestCase
         $this->assertSame(0, $result['error_code']);
         $this->assertSame('123456', $result['data']['kode_pt']);
     }
+
+    public function testGetListMahasiswaReturnsDataOnSuccess(): void
+    {
+        $responseBody = json_encode([
+            'error_code' => 0,
+            'data'       => [['nim' => '201731009', 'nama_mahasiswa' => 'Joko']],
+        ]);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getBody')->willReturn($responseBody);
+
+        $this->client = $this->createStub(CURLRequest::class);
+        $this->client->method('request')->willReturn($response);
+
+        $neoFeeder = new NeoFeeder($this->config, $this->client);
+        $result    = $neoFeeder->getListMahasiswa('token-abc', ['limit' => 20, 'offset' => 0]);
+
+        $this->assertSame(0, $result['error_code']);
+        $this->assertSame('201731009', $result['data'][0]['nim']);
+    }
+
+    public function testGetAktivitasKuliahMahasiswaReturnsDataOnSuccess(): void
+    {
+        $responseBody = json_encode([
+            'error_code' => 0,
+            'data'       => [['nim' => '201731009', 'ips' => '3.50']],
+        ]);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getBody')->willReturn($responseBody);
+
+        $this->client = $this->createStub(CURLRequest::class);
+        $this->client->method('request')->willReturn($response);
+
+        $neoFeeder = new NeoFeeder($this->config, $this->client);
+        $result    = $neoFeeder->getAktivitasKuliahMahasiswa('token-abc', ['limit' => 20, 'offset' => 0]);
+
+        $this->assertSame(0, $result['error_code']);
+        $this->assertSame('3.50', $result['data'][0]['ips']);
+    }
+
+    public function testGetListMahasiswaLulusDOReturnsDataOnSuccess(): void
+    {
+        $responseBody = json_encode([
+            'error_code' => 0,
+            'data'       => [['nim' => '201731009', 'nama_jenis_keluar' => 'Lulus']],
+        ]);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getBody')->willReturn($responseBody);
+
+        $this->client = $this->createStub(CURLRequest::class);
+        $this->client->method('request')->willReturn($response);
+
+        $neoFeeder = new NeoFeeder($this->config, $this->client);
+        $result    = $neoFeeder->getListMahasiswaLulusDO('token-abc', ['limit' => 20, 'offset' => 0]);
+
+        $this->assertSame(0, $result['error_code']);
+        $this->assertSame('Lulus', $result['data'][0]['nama_jenis_keluar']);
+    }
 }


### PR DESCRIPTION
## Summary

Implements ENH-014 (Issue #51): three read-only BASE pages that mirror the Neo Feeder menus used by the PISN graduation flow (ENH-013).

- `app/Libraries/NeoFeeder.php`: new `getListMahasiswa`, `getAktivitasKuliahMahasiswa`, `getListMahasiswaLulusDO` methods using the official WS request keys `filter`/`order`/`limit`/`offset` (per the Neo Feeder WS documentation).
- `app/Config/Routes.php`: three protected routes (`auth` + `csrf`).
- `app/Controllers/{Mahasiswa,AktivitasKuliah,MahasiswaLulusDo}.php`: GET filter form + `limit`/`offset` pagination; shared `collectFilters()` helper added to `BaseController`.
- `app/Views/{mahasiswa,aktivitas_kuliah,mahasiswa_lulus_do}/index.php`: data table + filter form + prev/next pagination; three new sidebar nav items.
- `tests/unit/Libraries/NeoFeederTest.php`: three success-path tests.
- `CHANGELOG.md` (Added) and `docs/IMPROVEMENTS.md` (ENH-014 → implemented) updated.

## Verification

- `php-cs-fixer` dry-run: 0 files to fix.
- `phpunit`: 18/18 pass (3 new).
- `php spark routes`: three routes registered with `auth csrf`.
- Live API probe confirmed dataset sizes (Mahasiswa 25,807 / Aktivitas Kuliah 222,147 / Lulus-DO 22,286 rows); pages filter/paginate server-side so tens of thousands of rows are never rendered at once.

## Notes

- Happy-path data rendering requires a non-expired Neo Feeder token; the session token in use during development had expired server-side, so live rendering was validated via the earlier API probe and unit tests rather than a live browser load. The error path (`error_code` 100) is handled gracefully with a non-crashing alert.

Fixes #51
