### PR TITLE
fix: forward route params to edit/delete controllers (BUG-001, #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ _None yet._
 - **Sidebar active state:** fixed route detection — `getPath()` returned `index.php/dashboard` instead of `dashboard`; now uses `current_url()` with `basename()` which handles both URL formats
 
 - **Windows php-cs-fixer CRLF false positives:** resolved by repo-wide LF normalization (`.editorconfig` `end_of_line = lf`, `.gitattributes` `* text=auto eol=lf`, `git add --renormalize .`); CI `build` now asserts LF line endings / no BOM on `*.md` — #48
+- **Neo Feeder edit/delete loader (BUG-001, #65):** the edit route handlers were defined without a `$1`/`$2` back-reference, so CodeIgniter 4.7.4 discarded the route parameter and `$id` was always `null` — the loader filtered by `null` and `GetBiodataMahasiswa`/`GetDetailPerkuliahanMahasiswa` returned empty, showing "Data tidak ditemukan." Fixed by adding `$1`/`$2` back-references to the route handlers (`Mahasiswa::edit/$1`, `AktivitasKuliah::edit/$1/$2`, etc.) and switching the loaders to the dedicated per-record endpoints with the SQL-string `filter` (`id_mahasiswa='…'`) — Edit/Delete now open the correct record.
 
 ### Removed
 _None yet._

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -26,12 +26,12 @@ $routes->get('mahasiswa-lulus-do', 'MahasiswaLulusDo::index');
  * Neo Feeder CRUD Routes (ENH-015)
  * --------------------------------------------------------------------
  */
-$routes->get('mahasiswa/edit/(:any)', 'Mahasiswa::edit');
-$routes->post('mahasiswa/edit/(:any)', 'Mahasiswa::editPost');
-$routes->post('mahasiswa/delete/(:any)', 'Mahasiswa::delete');
-$routes->get('aktivitas-kuliah/edit/(:any)/(:any)', 'AktivitasKuliah::edit');
-$routes->post('aktivitas-kuliah/edit/(:any)/(:any)', 'AktivitasKuliah::editPost');
-$routes->post('aktivitas-kuliah/delete/(:any)/(:any)', 'AktivitasKuliah::delete');
+$routes->get('mahasiswa/edit/(:any)', 'Mahasiswa::edit/$1');
+$routes->post('mahasiswa/edit/(:any)', 'Mahasiswa::editPost/$1');
+$routes->post('mahasiswa/delete/(:any)', 'Mahasiswa::delete/$1');
+$routes->get('aktivitas-kuliah/edit/(:any)/(:any)', 'AktivitasKuliah::edit/$1/$2');
+$routes->post('aktivitas-kuliah/edit/(:any)/(:any)', 'AktivitasKuliah::editPost/$1/$2');
+$routes->post('aktivitas-kuliah/delete/(:any)/(:any)', 'AktivitasKuliah::delete/$1/$2');
 
 /*
  * --------------------------------------------------------------------

--- a/app/Controllers/AktivitasKuliah.php
+++ b/app/Controllers/AktivitasKuliah.php
@@ -49,9 +49,9 @@ class AktivitasKuliah extends BaseController
         $token = session('auth.token');
 
         if ($token !== null && $idRegistrasi !== null && $idSemester !== null) {
-            $response = service('neoFeeder')->getAktivitasKuliahMahasiswa($token, [
-                'filter' => ['id_registrasi_mahasiswa' => $idRegistrasi, 'id_semester' => $idSemester],
-                'limit'  => 1,
+            $response = service('neoFeeder')->getDetailPerkuliahanMahasiswa($token, [
+                'id_registrasi_mahasiswa' => $idRegistrasi,
+                'id_semester'             => $idSemester,
             ]);
             if (($response['error_code'] ?? -1) === 0 && !empty($response['data'])) {
                 $row = $response['data'][0];

--- a/app/Controllers/Mahasiswa.php
+++ b/app/Controllers/Mahasiswa.php
@@ -45,11 +45,15 @@ class Mahasiswa extends BaseController
     {
         $username = service('auth')->getCurrentUser();
         $row = null;
-        $error = null;
         $token = session('auth.token');
+        $error = null;
 
         if ($token !== null && $id !== null) {
-            $response = service('neoFeeder')->getListMahasiswa($token, ['filter' => ['id_mahasiswa' => $id], 'limit' => 1]);
+            $idSafe = str_replace("'", "\'", (string) $id);
+            $response = service('neoFeeder')->getBiodataMahasiswa($token, [
+                'filter' => "id_mahasiswa='{$idSafe}'",
+                'limit'  => 1,
+            ]);
             if (($response['error_code'] ?? -1) === 0 && !empty($response['data'])) {
                 $row = $response['data'][0];
             } else {

--- a/app/Libraries/NeoFeeder.php
+++ b/app/Libraries/NeoFeeder.php
@@ -191,6 +191,36 @@ class NeoFeeder
     }
 
     /**
+     * Retrieves a single student's full biodata (GetBiodataMahasiswa).
+     *
+     * @param string $token   The authentication token obtained from getToken().
+     * @param array  $options Optional filter/order/limit/offset overrides.
+     *
+     * @return array The decoded API response on success, or a structured error array.
+     */
+    public function getBiodataMahasiswa(string $token, array $options = []): array
+    {
+        return $this->sendListRequest('GetBiodataMahasiswa', $token, $options);
+    }
+
+    /**
+     * Retrieves a single student course-activity record (GetDetailPerkuliahanMahasiswa).
+     *
+     * @param string $token The authentication token obtained from getToken().
+     * @param array  $key   The primary-key fields (id_registrasi_mahasiswa, id_semester).
+     *
+     * @return array The decoded API response on success, or a structured error array.
+     */
+    public function getDetailPerkuliahanMahasiswa(string $token, array $key): array
+    {
+        $idReg = str_replace("'", "\'", (string) ($key['id_registrasi_mahasiswa'] ?? ''));
+        $idSmt = str_replace("'", "\'", (string) ($key['id_semester'] ?? ''));
+        $filter = "id_registrasi_mahasiswa='{$idReg}' AND id_semester='{$idSmt}'";
+
+        return $this->sendListRequest('GetDetailPerkuliahanMahasiswa', $token, ['filter' => $filter]);
+    }
+
+    /**
      * Submits a graduated/dropped-out student record to the Neo Feeder API.
      *
      * @param string $token  The authentication token obtained from getToken().

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -330,15 +330,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** `—`
 
 ### BUG-001 — "Data tidak ditemukan." shown when pressing EDIT/DELETE
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #65
 - **Recorded:** 2026-08-27 23:35
-- **Implemented:** `—`
+- **Implemented:** `2026-08-28 06:44`
 - **Problem:** On the menu pages (Daftar Mahasiswa, Aktivitas Kuliah Mahasiswa) added in ENH-015, pressing the Edit or Delete action opens the edit page showing "Data tidak ditemukan." instead of the record. The Get-by-key load used by the edit handler returns no row, so the form cannot be prefilled and delete cannot resolve the key.
 - **Possible Fix:** Investigate the edit loader's Get call — likely the filter `id_mahasiswa` (or `id_registrasi_mahasiswa`+`id_semester`) does not match how the Neo Feeder API filters, or the column used as the key differs from the row's actual primary-key value. Fix the key/filter so the row is returned; add a check. Root cause to be confirmed in Verify.
-- **Actual Fix:** Confirmed: `Mahasiswa::edit`/`AktivitasKuliah::edit` call the list endpoints filtered by primary key and get no row, so the form shows "Data tidak ditemukan." The WS guide provides dedicated per-record endpoints: `GetBiodataMahasiswa` (3.7, filter-based, returns full biodata) and `GetDetailPerkuliahanMahasiswa` (3.128). Fix: add `getBiodataMahasiswa($token,$options)` and `getDetailPerkuliahanMahasiswa($token,$key)` to `NeoFeeder`, and switch both edit loaders to them. The `Update`/`Delete` mutations already send the correct `key`, so the round-trip works once the loader is fixed. Exact filter/key field names confirmed via a live re-probe (re-login to refresh the token) during implementation.
-- **Actual Implemented:** `—`
-- **Changes:** `—`
+- **Actual Fix:** Confirmed during implementation (live Playwright + CLI re-probe): the real cause was NOT the endpoint choice but the route definition. `Mahasiswa::edit`/`AktivitasKuliah::edit` were routed as `Controller::method` (e.g. `Mahasiswa::edit`) WITHOUT a `$1`/`$2` back-reference. In CodeIgniter 4.7.4 (`Router::checkRoutes`), such routes discard the captured route parameter, so `$this->params` is empty and the controller method is called with no arguments — `$id` was always `null`, the `filter` was built from `null`, and `GetBiodataMahasiswa`/`GetDetailPerkuliahanMahasiswa` returned empty → "Data tidak ditemukan." Fix: (1) route handlers use `$1`/`$2` back-references so the parameter is forwarded; (2) loaders use the dedicated per-record endpoints with the SQL-string `filter` (`id_mahasiswa='…'`, confirmed official WS format). The `Update`/`Delete` mutations already send the correct `key`, so the round-trip works once the loader receives a real `$id`.
+- **Actual Implemented:** Routes `mahasiswa/edit/(:any)` → `Mahasiswa::edit/$1` (and `editPost`/`delete` with `$1`), `aktivitas-kuliah/edit/(:any)/(:any)` → `AktivitasKuliah::edit/$1/$2` (and `editPost`/`delete` with `$1/$2`). Added `NeoFeeder::getBiodataMahasiswa($token, $options)` (GetBiodataMahasiswa, WS 3.7) and `NeoFeeder::getDetailPerkuliahanMahasiswa($token, $key)` (GetDetailPerkuliahanMahasiswa, WS 3.128, composite key). `Mahasiswa::edit` loads via `getBiodataMahasiswa(['filter' => "id_mahasiswa='{$idSafe}'", 'limit' => 1])`; `AktivitasKuliah::edit` via `getDetailPerkuliahanMahasiswa(['filter' => "id_registrasi_mahasiswa='{$idRegistrasi}' AND id_semester='{$idSemester}'"])`. Added 2 unit tests asserting `act` + SQL-string `filter` payload.
+- **Changes:** Edit/Delete on Daftar Mahasiswa and Aktivitas Kuliah Mahasiswa now open the correct record instead of "Data tidak ditemukan."; the edit form is prefilled and Delete resolves the primary key correctly.
 
 ### ENH-021 — Per-student detail page
 - **Status:** `verified`

--- a/tests/unit/Libraries/NeoFeederTest.php
+++ b/tests/unit/Libraries/NeoFeederTest.php
@@ -273,4 +273,54 @@ class NeoFeederTest extends CIUnitTestCase
         $this->assertSame(0, $result['error_code']);
         $this->assertSame('r-1', $result['data']['id_registrasi_mahasiswa']);
     }
+
+    public function testGetBiodataMahasiswaReturnsDataOnSuccess(): void
+    {
+        $responseBody = json_encode(['error_code' => 0, 'data' => [['id_mahasiswa' => 'uuid-1', 'nama_mahasiswa' => 'Budi']]]);
+        $captured     = [];
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getBody')->willReturn($responseBody);
+
+        $this->client = $this->createStub(CURLRequest::class);
+        $this->client->method('request')->willReturnCallback(function ($method, $url, $options) use (&$captured, $response) {
+            $captured = json_decode($options['body'], true);
+
+            return $response;
+        });
+
+        $neoFeeder = new NeoFeeder($this->config, $this->client);
+        $result    = $neoFeeder->getBiodataMahasiswa('token-abc', ['filter' => "id_mahasiswa='uuid-1'", 'limit' => 1]);
+
+        $this->assertSame(0, $result['error_code']);
+        $this->assertSame('GetBiodataMahasiswa', $captured['act']);
+        $this->assertSame("id_mahasiswa='uuid-1'", $captured['filter']);
+        $this->assertSame(1, $captured['limit']);
+    }
+
+    public function testGetDetailPerkuliahanMahasiswaReturnsDataOnSuccess(): void
+    {
+        $responseBody = json_encode(['error_code' => 0, 'data' => [['id_registrasi_mahasiswa' => 'r-1', 'id_semester' => '20231']]]);
+        $captured     = [];
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getBody')->willReturn($responseBody);
+
+        $this->client = $this->createStub(CURLRequest::class);
+        $this->client->method('request')->willReturnCallback(function ($method, $url, $options) use (&$captured, $response) {
+            $captured = json_decode($options['body'], true);
+
+            return $response;
+        });
+
+        $neoFeeder = new NeoFeeder($this->config, $this->client);
+        $result    = $neoFeeder->getDetailPerkuliahanMahasiswa('token-abc', [
+            'id_registrasi_mahasiswa' => 'r-1',
+            'id_semester'             => '20231',
+        ]);
+
+        $this->assertSame(0, $result['error_code']);
+        $this->assertSame('GetDetailPerkuliahanMahasiswa', $captured['act']);
+        $this->assertSame("id_registrasi_mahasiswa='r-1' AND id_semester='20231'", $captured['filter']);
+    }
 }


### PR DESCRIPTION
## Summary

Edit/Delete actions on the Daftar Mahasiswa and Aktivitas Kuliah Mahasiswa menu pages opened the edit form with "Data tidak ditemukan." The route handlers were defined as `Controller::method` without a `$1`/`$2` back-reference, so CodeIgniter 4.7.4 discarded the route parameter and the controller received `$id = null`. Route handlers now use `$1`/`$2` back-references and the loaders use the dedicated per-record Neo Feeder endpoints with the SQL-string `filter`.

## Related issues

Fixes #65

## Checklist

- [x] `php -l` passes on all modified PHP files
- [ ] `npm run build` succeeds and committed assets are up to date (no asset changes in this PR)
- [x] `php spark routes` shows correct new routes (edit/delete routes now forward params)
- [x] `vendor/bin/php-cs-fixer fix` passes (no style violations)
- [x] `vendor/bin/phpunit` is green (36/36; +2 Get-endpoint cases)
- [x] No debug code
- [x] All POST forms include `csrf_field()` (inherited from ENH-015 views)
- [x] No unrelated files changed
- [x] CHANGELOG updated
- [x] Behaviour verified in browser (Edit prefills record; Delete resolves key)

## Screenshot (if applicable)

## Notes for reviewers

Root cause was the missing `$1`/`$2` route back-reference, not the API filter format. `NeoFeeder::getDetailPerkuliahanMahasiswa` builds the composite-key SQL filter internally.