### PR TITLE
feat: add pre-submit preview for PISN graduation (ENH-019, #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _None yet._
 - **Excel support:** added `phpoffice/phpspreadsheet` dependency for graduation candidate upload — ENH-013, #53
 - **Neo Feeder CRUD (Biodata & Perkuliahan):** edit/delete actions on `Daftar Mahasiswa` (`/mahasiswa/edit`, `/mahasiswa/delete`) and `Aktivitas Kuliah Mahasiswa` (`/aktivitas-kuliah/edit`, `/aktivitas-kuliah/delete`) wired to NeoFeeder `Insert`/`Update`/`Delete` WS actions via the service layer. Forms are generated from the returned row columns; composite primary key (`id_registrasi_mahasiswa`+`id_semester`) handled for Perkuliahan. `Mahasiswa Lulus/DO` mutation endpoints are not documented in the available guide, so no CRUD was added there — ENH-015, #52
 - **PISN graduation Excel template:** downloadable `.xlsx` template with headers (nim, nama, jenis_keluar, tgl_keluar, periode_keluar, ipk) and an example row on `graduation/upload` page — ENH-018, #70
+- **PISN graduation pre-submit preview:** consolidated preview page (`/graduation/preview`) listing all verified students' graduation data before Neo Feeder submission, with explicit "Kirim ke Neo Feeder" confirmation — ENH-019, #64
 
 ### Changed
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -45,3 +45,5 @@ $routes->get('graduation/step', 'Graduation::step');
 $routes->post('graduation/step', 'Graduation::stepPost');
 $routes->get('graduation/guidance', 'Graduation::guidance');
 $routes->get('graduation/template', 'Graduation::downloadTemplate');
+$routes->get('graduation/preview', 'Graduation::preview');
+$routes->post('graduation/finish', 'Graduation::finish');

--- a/app/Controllers/Graduation.php
+++ b/app/Controllers/Graduation.php
@@ -272,7 +272,7 @@ class Graduation extends BaseController
             $progress['current'] = $idx + 1;
             $this->wizard->save($token, $progress);
 
-            return $this->finish();
+            return redirect()->to('graduation/preview');
         }
 
         $progress['current'] = $idx + 1;
@@ -284,7 +284,7 @@ class Graduation extends BaseController
     /**
      * Submits every verified student to Neo Feeder, then shows guidance.
      */
-    private function finish(): string
+    public function finish(): string
     {
         $token    = $this->currentToken();
         $progress = $this->loadProgress();
@@ -335,6 +335,24 @@ class Graduation extends BaseController
         session()->setFlashdata('graduation_results', $results);
 
         return redirect()->to('graduation/guidance');
+    }
+
+    /**
+     * GET /graduation/preview — preview all verified students before submission.
+     */
+    public function preview()
+    {
+        $progress = $this->loadProgress();
+        if ($progress === null) {
+            return redirect()->to('graduation');
+        }
+
+        $username = service('auth')->getCurrentUser() ?? '';
+
+        return $this->render('graduation/preview', [
+            'username' => $username,
+            'students' => $progress['students'],
+        ]);
     }
 
     /**

--- a/app/Views/graduation/preview.php
+++ b/app/Views/graduation/preview.php
@@ -1,0 +1,74 @@
+<div class="app-content-header">
+    <div class="container-fluid">
+        <div class="row mb-2">
+            <div class="col-sm-6">
+                <h3 class="m-0">Konfirmasi Data Kelulusan</h3>
+            </div>
+            <div class="col-sm-6">
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb float-sm-end">
+                        <li class="breadcrumb-item"><a href="<?= base_url('dashboard') ?>">Home</a></li>
+                        <li class="breadcrumb-item"><a href="<?= base_url('graduation') ?>">PISN Graduation</a></li>
+                        <li class="breadcrumb-item active">Konfirmasi</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="app-content">
+    <div class="container-fluid">
+        <div class="alert alert-info">
+            <i class="fas fa-info-circle"></i> Silakan periksa data kelulusan berikut sebelum mengirim ke Neo Feeder. Klik <strong>Kirim ke Neo Feeder</strong> untuk memproses, atau <strong>Kembali</strong> untuk mengubah data.
+        </div>
+
+        <?php if (empty($students)): ?>
+            <div class="alert alert-warning">Tidak ada data mahasiswa untuk dikonfirmasi.</div>
+        <?php else: ?>
+            <div class="card">
+                <div class="card-body table-responsive">
+                    <table class="table table-bordered table-striped">
+                        <thead class="table-light">
+                            <tr>
+                                <th>#</th>
+                                <th>NIM</th>
+                                <th>Nama</th>
+                                <th>Jenis Keluar</th>
+                                <th>Tanggal Keluar/Lulus</th>
+                                <th>Periode Keluar</th>
+                                <th>IPK</th>
+                                <th>No Ijazah / No Sertifikat Profesi</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($students as $idx => $student): ?>
+                                <?php $g = $student['graduation'] ?? []; ?>
+                                <tr>
+                                    <td><?= esc($idx + 1) ?></td>
+                                    <td><?= esc($g['nim'] ?? $student['nim'] ?? '') ?></td>
+                                    <td><?= esc($g['nama'] ?? $student['nama'] ?? '') ?></td>
+                                    <td><?= esc($g['jenis_keluar'] ?? $student['jenis_keluar'] ?? '') ?></td>
+                                    <td><?= esc($g['tgl_keluar'] ?? $student['tgl_keluar'] ?? '') ?></td>
+                                    <td><?= esc($g['periode_keluar'] ?? $student['periode_keluar'] ?? '') ?></td>
+                                    <td><?= esc($g['ipk'] ?? $student['ipk'] ?? '') ?></td>
+                                    <td><?= esc($g['no_ijazah'] ?? '-') ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="card-footer d-flex justify-content-between">
+                    <a href="<?= base_url('graduation/step') ?>" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left"></i> Kembali
+                    </a>
+                    <form method="post" action="<?= base_url('graduation/finish') ?>">
+                        <?= csrf_field() ?>
+                        <button type="submit" class="btn btn-primary" onclick="return confirm('Yakin ingin mengirim data ini ke Neo Feeder?');">
+                            <i class="fas fa-paper-plane"></i> Kirim ke Neo Feeder
+                        </button>
+                    </form>
+                </div>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>

--- a/app/Views/graduation/wizard.php
+++ b/app/Views/graduation/wizard.php
@@ -119,8 +119,8 @@
 
             <div class="d-flex justify-content-between">
                 <a href="<?= base_url('graduation') ?>" class="btn btn-outline-secondary">Batal</a>
-                <button type="submit" class="btn btn-primary">
-                    <?= $isLast ? 'Selesai &amp; Kirim' : 'Berikutnya' ?> <i class="fas fa-arrow-right"></i>
+<button type="submit" class="btn btn-primary">
+                    Berikutnya <i class="fas fa-arrow-right"></i>
                 </button>
             </div>
         </form>

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -308,15 +308,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** Admins can now download a ready-to-use Excel template with correct column headers and an example row, eliminating formatting errors when preparing graduation candidate data for upload.
 
 ### ENH-019 — Pre-submit preview of PISN Graduation data
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #64
 - **Recorded:** 2026-08-27 23:35
-- **Implemented:** `—`
+- **Implemented:** 2026-08-28 11:15
 - **Problem:** After all students are verified in the ENH-013 wizard, there is no consolidated preview/confirmation screen before the data is submitted (registered) to PDDIKTI via `InsertMahasiswaLulusDO`. A mistake is only visible after submission.
 - **Possible Fix:** Add a final preview/confirmation step in the graduation wizard that lists every verified student and the values to be submitted, with an explicit "Submit" action only after review.
 - **Actual Fix:** Change `Graduation::stepPost()` so that on the last student it redirects to a new preview page (instead of calling `finish()` directly). The preview lists every verified student and the values to be submitted, with an explicit "Submit" button that triggers `finish()`. No behavior change to the submission itself.
-- **Actual Implemented:** `—`
-- **Changes:** `—`
+- **Actual Implemented:** Added routes `GET /graduation/preview` → `Graduation::preview()` and `POST /graduation/finish` → `Graduation::finish()`; modified `stepPost()` to redirect to preview on last student; made `finish()` public; added `preview()` method loading wizard progress and rendering preview view; created `app/Views/graduation/preview.php` with table of all verified students' graduation data and "Kirim ke Neo Feeder" button; updated wizard button text to "Berikutnya".
+- **Changes:** Admins now see a consolidated preview page listing all verified students' graduation data (NIM, Nama, Jenis Keluar, Tanggal Keluar/Lulus, Periode Keluar, IPK, No Ijazah) before submission, with explicit "Kirim ke Neo Feeder" confirmation, reducing risk of transmitting incorrect data.
 
 ### ENH-020 — Completeness check of student grades (especially thesis grade) in PISN Graduation via GetTranskripMahasiswa
 - **Status:** `verified`


### PR DESCRIPTION
## Summary

Adds a pre-submit preview page for the PISN Graduation wizard. After verifying the last student, the admin is redirected to a consolidated preview page listing all verified students' graduation data before submission to Neo Feeder.

## Related issues

Fixes #64

## Checklist

- [x] `php -l` passes on all modified PHP files
- [x] `npm run build` succeeds and committed assets are up to date
- [x] `php spark routes` shows correct new routes (if routes changed)
- [x] `vendor/bin/php-cs-fixer fix` passes (no style violations)
- [x] `vendor/bin/phpunit` is green (if tests exist)
- [x] No debug code: `dd()`, `var_dump()`, `console.log()`, `print_r()`, `exit()`
- [x] All user inputs validated server-side
- [x] All POST forms include `csrf_field()`
- [x] All HTML output uses `esc()`
- [x] No unrelated files changed
- [x] CHANGELOG updated if this is a user-facing change
- [x] Behaviour verified in the browser if UI changed (attach a screenshot if useful)

## Screenshot (if applicable)

<!-- Paste screenshots here -->

## Notes for reviewers

- Added routes `GET /graduation/preview` and `POST /graduation/finish`
- Modified `Graduation::stepPost()` to redirect to preview on last student instead of calling `finish()` directly
- Made `finish()` public (was private) to be callable via route
- Added `Graduation::preview()` method that loads wizard progress and renders preview view
- Created new view `app/Views/graduation/preview.php` with table of all 7 graduation columns (NIM, Nama, Jenis Keluar, Tanggal Keluar/Lulus, Periode Keluar, IPK, No Ijazah)
- Preview page has "Kirim ke Neo Feeder" button (POST to `graduation/finish` with confirmation) and "Kembali" link to return to wizard
- Updated wizard button text from "Selesai & Kirim" to "Berikutnya" on last student
- Updated IMPROVEMENTS.md (ENH-019 → implemented) and CHANGELOG.md