### PR TITLE
fix: fix filter format in Graduation wizard step (BUG-002, #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ _None yet._
 
 - **Windows php-cs-fixer CRLF false positives:** resolved by repo-wide LF normalization (`.editorconfig` `end_of_line = lf`, `.gitattributes` `* text=auto eol=lf`, `git add --renormalize .`); CI `build` now asserts LF line endings / no BOM on `*.md` — #48
 - **Neo Feeder edit/delete loader (BUG-001, #65):** the edit route handlers were defined without a `$1`/`$2` back-reference, so CodeIgniter 4.7.4 discarded the route parameter and `$id` was always `null` — the loader filtered by `null` and `GetBiodataMahasiswa`/`GetDetailPerkuliahanMahasiswa` returned empty, showing "Data tidak ditemukan." Fixed by adding `$1`/`$2` back-references to the route handlers (`Mahasiswa::edit/$1`, `AktivitasKuliah::edit/$1/$2`, etc.) and switching the loaders to the dedicated per-record endpoints with the SQL-string `filter` (`id_mahasiswa='…'`) — Edit/Delete now open the correct record.
+- **Graduation wizard filter format (BUG-002, #75):** the `Graduation::step()` method passed `filter` as an array `['nim' => ...]` to `getListMahasiswa()` and `getAktivitasKuliahMahasiswa()`, but the NeoFeeder API expects a SQL WHERE-string. The API silently returned empty data, causing "Gagal memuat data mahasiswa." on the first wizard step. Fixed by sanitizing the NIM and passing SQL-string filter `nim='...'` to both calls.
 
 ### Removed
 _None yet._

--- a/app/Controllers/Graduation.php
+++ b/app/Controllers/Graduation.php
@@ -162,20 +162,22 @@ class Graduation extends BaseController
         $error    = null;
 
         if ($apiToken !== null) {
-            $idResp = $this->neoFeeder->getListMahasiswa(
-                $apiToken,
-                ['filter' => ['nim' => $student['nim']], 'limit' => 1]
-            );
+            $nimSafe = str_replace("'", "\'", (string) $student['nim']);
+
+            $idResp = $this->neoFeeder->getListMahasiswa($apiToken, [
+                'filter' => "nim='{$nimSafe}'",
+                'limit'  => 1,
+            ]);
             if (($idResp['error_code'] ?? -1) === 0 && isset($idResp['data'][0])) {
                 $identity = $idResp['data'][0];
             } else {
                 $error = $idResp['error_msg'] ?? 'Gagal memuat data mahasiswa.';
             }
 
-            $acResp = $this->neoFeeder->getAktivitasKuliahMahasiswa(
-                $apiToken,
-                ['filter' => ['nim' => $student['nim']], 'limit' => 50]
-            );
+            $acResp = $this->neoFeeder->getAktivitasKuliahMahasiswa($apiToken, [
+                'filter' => "nim='{$nimSafe}'",
+                'limit'  => 50,
+            ]);
             if (($acResp['error_code'] ?? -1) === 0 && isset($acResp['data'])) {
                 $academic = $acResp['data'];
             }

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -363,15 +363,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** `—`
 
 ### BUG-002 — Filter format bug in Graduation wizard causes "Gagal memuat data mahasiswa."
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #75
 - **Recorded:** 2026-08-28 11:30
-- **Implemented:** `—`
+- **Implemented:** 2026-08-28 15:57
 - **Problem:** Immediately after uploading Excel and starting verification on the PISN Graduation wizard, the first student shows "Gagal memuat data mahasiswa." The `Graduation::step()` method calls `getListMahasiswa()` with `filter` as an array `['nim' => '...']`, but the NeoFeeder API expects SQL WHERE-string format (`nim='...'`). The API silently returns empty data.
 - **Possible Fix:** Change the filter format in `Graduation::step()` from array to SQL-string: `['filter' => "nim='{$nimSafe}'"]` (matching BUG-001 fix pattern for `getBiodataMahasiswa`). Also apply same fix to `getAktivitasKuliahMahasiswa()` call in the same method.
 - **Actual Fix:** In `Graduation::step()`, sanitize NIM with `$nimSafe = str_replace("'", "\'", (string) $student['nim'])`, then pass SQL-string filter to both `getListMahasiswa()` and `getAktivitasKuliahMahasiswa()`: `['filter' => "nim='{$nimSafe}'", 'limit' => 1]` and `['filter' => "nim='{$nimSafe}'", 'limit' => 50]`. Matches BUG-001 fix pattern; confirmed per WS guide format (sections 3.7 / 3.128) and constraint #153.
-- **Actual Implemented:** `—`
-- **Changes:** `—`
+- **Actual Implemented:** Changed `Graduation::step()` lines 165-178 to use SQL-string filter format with sanitized NIM instead of array filter; applied to both `getListMahasiswa()` and `getAktivitasKuliahMahasiswa()` calls.
+- **Changes:** Graduation wizard step now loads student identity and academic data correctly; the "Gagal memuat data mahasiswa." error is fixed.
 
 ### ENH-023 — Add "Batalkan sesi" button to clear wizard session
 - **Status:** `verified`


### PR DESCRIPTION
## Summary

Fixes the "Gagal memuat data mahasiswa." error on the first PISN Graduation wizard step. The `Graduation::step()` method passed the NeoFeeder `filter` parameter as a PHP array (`['nim' => ...]`), but the API expects a SQL WHERE-string (`nim='...'`). The API silently returned empty data, blocking verification.

## Related issues

Fixes #75

## Checklist

- [x] `php -l` passes on all modified PHP files
- [x] `npm run build` succeeds and committed assets are up to date
- [x] `php spark routes` shows correct new routes (if routes changed)
- [x] `vendor/bin/php-cs-fixer fix` passes (no style violations)
- [x] `vendor/bin/phpunit` is green (36 tests, 69 assertions)
- [x] No debug code: `dd()`, `var_dump()`, `console.log()`, `print_r()`, `exit()`
- [x] All user inputs validated server-side
- [x] All POST forms include `csrf_field()`
- [x] All HTML output uses `esc()`
- [x] No unrelated files changed
- [x] CHANGELOG updated if this is a user-facing change
- [x] Behaviour verified in the browser if UI changed (attach a screenshot if useful)

## Screenshot (if applicable)

<!-- Wizard step now loads student identity + academic data -->

## Notes for reviewers

- Single atomic commit on `fix/graduation-filter-format` from `main`
- Filter format fix matches BUG-001 pattern (Mahasiswa::edit)
- NIM sanitized with `str_replace("'", "\'", ...)` before embedding in SQL string