### PR TITLE
feat: add 'Batalkan sesi' button to clear wizard session (ENH-023, #76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _None yet._
 - **Neo Feeder CRUD (Biodata & Perkuliahan):** edit/delete actions on `Daftar Mahasiswa` (`/mahasiswa/edit`, `/mahasiswa/delete`) and `Aktivitas Kuliah Mahasiswa` (`/aktivitas-kuliah/edit`, `/aktivitas-kuliah/delete`) wired to NeoFeeder `Insert`/`Update`/`Delete` WS actions via the service layer. Forms are generated from the returned row columns; composite primary key (`id_registrasi_mahasiswa`+`id_semester`) handled for Perkuliahan. `Mahasiswa Lulus/DO` mutation endpoints are not documented in the available guide, so no CRUD was added there — ENH-015, #52
 - **PISN graduation Excel template:** downloadable `.xlsx` template with headers (nim, nama, jenis_keluar, tgl_keluar, periode_keluar, ipk) and an example row on `graduation/upload` page — ENH-018, #70
 - **PISN graduation pre-submit preview:** consolidated preview page (`/graduation/preview`) listing all verified students' graduation data before Neo Feeder submission, with explicit "Kirim ke Neo Feeder" confirmation — ENH-019, #64
+- **PISN graduation cancel session:** "Batalkan sesi" button on the upload page that clears the wizard progress cache and resume cookie, returning to a fresh upload form without waiting for the 24h TTL — ENH-023, #76
 
 ### Changed
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -47,3 +47,4 @@ $routes->get('graduation/guidance', 'Graduation::guidance');
 $routes->get('graduation/template', 'Graduation::downloadTemplate');
 $routes->get('graduation/preview', 'Graduation::preview');
 $routes->post('graduation/finish', 'Graduation::finish');
+$routes->post('graduation/cancel', 'Graduation::cancel');

--- a/app/Controllers/Graduation.php
+++ b/app/Controllers/Graduation.php
@@ -143,6 +143,20 @@ class Graduation extends BaseController
     }
 
     /**
+     * POST /graduation/cancel — clear an interrupted wizard session.
+     */
+    public function cancel()
+    {
+        $token = $this->currentToken();
+        if ($token !== null) {
+            $this->wizard->clear($token);
+            service('auth')->clearWizardResumeCookie();
+        }
+
+        return redirect()->to('graduation');
+    }
+
+    /**
      * GET /graduation/step — show the current student verification screen.
      */
     public function step()

--- a/app/Views/graduation/upload.php
+++ b/app/Views/graduation/upload.php
@@ -27,7 +27,13 @@
         <?php if ($canResume): ?>
             <div class="alert alert-info d-flex justify-content-between align-items-center">
                 <span><i class="fas fa-rotate"></i> Ada sesi verifikasi yang belum selesai.</span>
-                <a href="<?= base_url('graduation/resume') ?>" class="btn btn-sm btn-primary">Lanjutkan</a>
+                <div class="d-flex gap-2">
+                    <a href="<?= base_url('graduation/resume') ?>" class="btn btn-sm btn-primary">Lanjutkan</a>
+                    <form action="<?= base_url('graduation/cancel') ?>" method="post">
+                        <?= csrf_field() ?>
+                        <button type="submit" class="btn btn-sm btn-outline-danger">Batalkan sesi</button>
+                    </form>
+                </div>
             </div>
         <?php endif; ?>
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -374,12 +374,12 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** Graduation wizard step now loads student identity and academic data correctly; the "Gagal memuat data mahasiswa." error is fixed.
 
 ### ENH-023 — Add "Batalkan sesi" button to clear wizard session
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #76
 - **Recorded:** 2026-08-28 11:30
-- **Implemented:** `—`
+- **Implemented:** 2026-08-28 16:05
 - **Problem:** The upload page shows "Ada sesi verifikasi yang belum selesai" with "Lanjutkan" but no way to explicitly cancel/clear the session. Old sessions remain in cache until 24h TTL expires.
 - **Possible Fix:** Add "Batalkan sesi" button on `graduation/upload` view that calls a new route `POST /graduation/cancel` → `Graduation::cancel()`, which clears the wizard cache entry and the resume cookie, then redirects to `graduation`.
 - **Actual Fix:** Add route `POST /graduation/cancel` → `Graduation::cancel()`; controller method clears wizard cache via `$this->wizard->clear($token)` and resume cookie via `service('auth')->clearWizardResumeCookie()`, then redirects to `graduation`; view adds "Batalkan sesi" button (form POST) alongside "Lanjutkan" in the resume alert.
-- **Actual Implemented:** `—`
-- **Changes:** `—`
+- **Actual Implemented:** Added `POST /graduation/cancel` route to `Routes.php`; added `Graduation::cancel()` method that clears WizardProgress cache entry and resume cookie then redirects to upload; updated `graduation/upload.php` resume alert to include a "Batalkan sesi" form button (CSRF-protected) beside "Lanjutkan".
+- **Changes:** Graduation upload page now offers explicit session cancellation; admins no longer wait for 24h TTL to clear an unfinished verification session.


### PR DESCRIPTION
## Summary

Adds a "Batalkan sesi" button to the PISN Graduation upload page so admins can explicitly clear an unfinished verification session instead of waiting for the 24h cache TTL to expire. The button posts to a new `POST /graduation/cancel` route, which clears the wizard progress cache entry and the resume cookie, then redirects back to the fresh upload form.

## Related issues

Fixes #76

## Checklist

- [x] `php -l` passes on all modified PHP files
- [x] `npm run build` succeeds and committed assets are up to date
- [x] `php spark routes` shows correct new routes (if routes changed)
- [x] `vendor/bin/php-cs-fixer fix` passes (no style violations)
- [x] `vendor/bin/phpunit` is green (36 tests, 69 assertions)
- [x] No debug code: `dd()`, `var_dump()`, `console.log()`, `print_r()`, `exit()`
- [x] All user inputs validated server-side
- [x] All POST forms include `csrf_field()`
- [x] All HTML output uses `esc()`
- [x] No unrelated files changed
- [x] CHANGELOG updated if this is a user-facing change
- [x] Behaviour verified in the browser if UI changed (attach a screenshot if useful)

## Screenshot (if applicable)

<!-- Upload page resume alert now shows 'Lanjutkan' + 'Batalkan sesi' -->

## Notes for reviewers

- Single atomic commit on `feature/cancel-wizard-session` from `main`
- Reuses existing ENH-016 infra: `WizardProgress::clear()` + `Auth::clearWizardResumeCookie()`
- Cancel form is CSRF-protected; "Lanjutkan" remains a GET link