### PR TITLE
feat: add transcript completeness check in graduation wizard (ENH-020, #67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _None yet._
 - **PISN graduation Excel template:** downloadable `.xlsx` template with headers (nim, nama, jenis_keluar, tgl_keluar, periode_keluar, ipk) and an example row on `graduation/upload` page — ENH-018, #70
 - **PISN graduation pre-submit preview:** consolidated preview page (`/graduation/preview`) listing all verified students' graduation data before Neo Feeder submission, with explicit "Kirim ke Neo Feeder" confirmation — ENH-019, #64
 - **PISN graduation cancel session:** "Batalkan sesi" button on the upload page that clears the wizard progress cache and resume cookie, returning to a fresh upload form without waiting for the 24h TTL — ENH-023, #76
+- **PISN graduation transcript completeness check:** the graduation wizard loads each student's transcript (GetTranskripMahasiswa) and shows a "Kelengkapan Transkrip" card with a green "Lengkap" / red "Belum lengkap" badge when the thesis/skripsi grade is missing (soft warning, Next stays enabled) — ENH-020, #67
 
 ### Changed
 

--- a/app/Controllers/Graduation.php
+++ b/app/Controllers/Graduation.php
@@ -171,9 +171,11 @@ class Graduation extends BaseController
         $student  = $progress['students'][$idx];
         $apiToken = session('auth.token');
 
-        $identity = null;
-        $academic = null;
-        $error    = null;
+        $identity    = null;
+        $academic    = null;
+        $transcript  = null;
+        $completeness = null;
+        $error       = null;
 
         if ($apiToken !== null) {
             $nimSafe = str_replace("'", "\'", (string) $student['nim']);
@@ -195,6 +197,18 @@ class Graduation extends BaseController
             if (($acResp['error_code'] ?? -1) === 0 && isset($acResp['data'])) {
                 $academic = $acResp['data'];
             }
+
+            if ($identity !== null && isset($identity['id_registrasi_mahasiswa'])) {
+                $idReg = str_replace("'", "\'", (string) $identity['id_registrasi_mahasiswa']);
+                $trResp = $this->neoFeeder->getTranskripMahasiswa($apiToken, [
+                    'filter' => "id_registrasi_mahasiswa='{$idReg}'",
+                    'limit'  => 200,
+                ]);
+                if (($trResp['error_code'] ?? -1) === 0 && isset($trResp['data'])) {
+                    $transcript   = $trResp['data'];
+                    $completeness = $this->checkTranscriptCompleteness($transcript);
+                }
+            }
         } else {
             $error = 'Sesi token habis; silakan login ulang, lalu klik Lanjutkan.';
         }
@@ -203,17 +217,55 @@ class Graduation extends BaseController
         $total = count($progress['students']);
 
         return $this->render('graduation/wizard', [
-            'username' => $username,
-            'index'    => $idx,
-            'total'    => $total,
-            'student'  => $student,
-            'identity' => $identity,
-            'academic' => $academic,
-            'pisn'     => $pisn,
-            'error'    => $error,
-            'isLast'   => ($idx === $total - 1),
-            'saved'    => $student['saved'] ?? false,
+            'username'     => $username,
+            'index'        => $idx,
+            'total'        => $total,
+            'student'      => $student,
+            'identity'     => $identity,
+            'academic'     => $academic,
+            'transcript'   => $transcript,
+            'completeness' => $completeness,
+            'pisn'         => $pisn,
+            'error'        => $error,
+            'isLast'       => ($idx === $total - 1),
+            'saved'        => $student['saved'] ?? false,
         ]);
+    }
+
+    /**
+     * Checks whether a student's transcript is complete for graduation.
+     *
+     * The GetTranskripMahasiswa response carries per-course final grades
+     * (nilai_angka / nilai_huruf / nilai_indeks) and does NOT include an
+     * id_jenis_mata_kuliah type flag, so the thesis/skripsi course is detected
+     * by its course name. A transcript is complete when it is non-empty and
+     * contains a thesis-named row with a non-empty grade.
+     *
+     * The thesis-name pattern is a heuristic; confirm the exact course naming
+     * against a graduating student's transcript and tighten the pattern if needed.
+     *
+     * @param array $transcript Rows from GetTranskripMahasiswa.
+     *
+     * @return array{complete:bool, reason:string}
+     */
+    private function checkTranscriptCompleteness(array $transcript): array
+    {
+        if (empty($transcript)) {
+            return ['complete' => false, 'reason' => 'Transkrip kosong (tidak ada nilai).'];
+        }
+
+        $thesisPattern = '/skripsi|tugas\s*akhir|thesis|disertasi/i';
+        foreach ($transcript as $row) {
+            $name = $row['nama_mata_kuliah'] ?? '';
+            if (preg_match($thesisPattern, $name)) {
+                $nilai = $row['nilai_huruf'] ?? ($row['nilai_angka'] ?? null);
+                if ($nilai !== null && $nilai !== '') {
+                    return ['complete' => true, 'reason' => ''];
+                }
+            }
+        }
+
+        return ['complete' => false, 'reason' => 'Nilai skripsi/tugas akhir belum terdeteksi di transkrip.'];
     }
 
     /**

--- a/app/Libraries/NeoFeeder.php
+++ b/app/Libraries/NeoFeeder.php
@@ -191,6 +191,19 @@ class NeoFeeder
     }
 
     /**
+     * Retrieves a student's academic transcript (GetTranskripMahasiswa).
+     *
+     * @param string $token   The authentication token obtained from getToken().
+     * @param array  $options Optional filter/order/limit/offset overrides.
+     *
+     * @return array The decoded API response on success, or a structured error array.
+     */
+    public function getTranskripMahasiswa(string $token, array $options = []): array
+    {
+        return $this->sendListRequest('GetTranskripMahasiswa', $token, $options);
+    }
+
+    /**
      * Retrieves a single student's full biodata (GetBiodataMahasiswa).
      *
      * @param string $token   The authentication token obtained from getToken().

--- a/app/Views/graduation/wizard.php
+++ b/app/Views/graduation/wizard.php
@@ -83,6 +83,26 @@
             </div>
 
             <div class="card mb-3">
+                <div class="card-header"><i class="fas fa-clipboard-check"></i> 2b. Kelengkapan Transkrip</div>
+                <div class="card-body">
+                    <?php if ($transcript === null): ?>
+                        <div class="text-muted">Data transkrip tidak dapat dimuat.</div>
+                    <?php else: ?>
+                        <?php if (! empty($completeness['complete'])): ?>
+                            <div class="alert alert-success py-2 mb-2">
+                                <i class="fas fa-circle-check"></i> Transkrip lengkap — nilai skripsi/tugas akhir tersedia.
+                            </div>
+                        <?php else: ?>
+                            <div class="alert alert-warning py-2 mb-2">
+                                <i class="fas fa-triangle-exclamation"></i> Transkrip belum lengkap: <?= esc($completeness['reason'] ?? 'periksa nilai.') ?>
+                            </div>
+                        <?php endif; ?>
+                        <div class="text-muted small">Jumlah nilai terload: <?= esc(count($transcript)) ?></div>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="card mb-3">
                 <div class="card-header"><i class="fas fa-certificate"></i> 3. Eligibilitas PISN</div>
                 <div class="card-body">
                     <?php if (! empty($pisn['available'])): ?>

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -319,15 +319,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** Admins now see a consolidated preview page listing all verified students' graduation data (NIM, Nama, Jenis Keluar, Tanggal Keluar/Lulus, Periode Keluar, IPK, No Ijazah) before submission, with explicit "Kirim ke Neo Feeder" confirmation, reducing risk of transmitting incorrect data.
 
 ### ENH-020 — Completeness check of student grades (especially thesis grade) in PISN Graduation via GetTranskripMahasiswa
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #67
 - **Recorded:** 2026-08-27 23:35
-- **Implemented:** `—`
+- **Implemented:** 2026-08-28 16:40
 - **Problem:** Before submitting graduation data, the admin must ensure all grades — especially the thesis (skripsi) grade — are entered. BASE currently has no completeness check and no source for an individual student's grades.
 - **Possible Fix:** Add a validation step in the graduation wizard that confirms required grade fields are present. Source the grades from a new Neo Feeder call (candidate `GetTranskripMahasiswa`) or a new menu/endpoint; confirm the exact `act` name and response schema during Verify (and implementation). May include a new transcript menu page.
 - **Actual Fix:** Add `getTranskripMahasiswa($token, $options)` to `NeoFeeder` (filter-based Get, per WS guide 3.86) and call it in `Graduation::step` (filter by `id_registrasi_mahasiswa`/nim) to retrieve the transcript; validate that the thesis/skripsi grade field is present and non-empty before allowing Next. The exact grade field name is confirmed against the live API during implementation.
-- **Actual Implemented:** `—`
-- **Changes:** `—`
+- **Actual Implemented:** Added `NeoFeeder::getTranskripMahasiswa($token, $options)` (GetTranskripMahasiswa, WS 3.86) and a private `Graduation::checkTranscriptCompleteness()` helper. `Graduation::step()` loads the transcript via `getTranskripMahasiswa(['filter' => "id_registrasi_mahasiswa='…'"])` when identity is available, then computes completeness. The wizard view shows a "2b. Kelengkapan Transkrip" card with a green "Lengkap" / red "Belum lengkap: <reason>" badge (soft warning — Next stays enabled, matching the manual-verification design). Live-API probe (2026-08-28) confirmed: GetTranskripMahasiswa rows have NO `id_jenis_mata_kuliah` type flag and use grade fields `nilai_angka`/`nilai_huruf`/`nilai_indeks` (not `nilai_akhir`); GetAktivitasKuliahMahasiswa is per-semester summary (IPK/sks_total), not per-course grades. Thesis/skripsi is therefore detected by course name (`nama_mata_kuliah` matches `/skripsi|tugas akhir|thesis|disertasi/i`) with a non-empty `nilai_huruf`/`nilai_angka`. **Confirmed against live data:** this institution's thesis course is named `Skripsi` (also `THESIS`); `LIKE '%SKRIPSI%'` returned real rows with `nilai_huruf='A'`, and the pattern matches. NPM `202010087` (MUH ANDY RIZALDI) has 52 graded courses but no `Skripsi` row — the check correctly flags the thesis as not yet entered.
+- **Changes:** Graduation wizard now surfaces transcript completeness (thesis grade present) per student; admins get a warning when the thesis grade is missing instead of discovering it after submission.
 
 ### BUG-001 — "Data tidak ditemukan." shown when pressing EDIT/DELETE
 - **Status:** `implemented`


### PR DESCRIPTION
## Summary

Adds a transcript completeness check to the PISN Graduation wizard (ENH-020, #67).

- **NeoFeeder:** new `getTranskripMahasiswa()` (GetTranskripMahasiswa, WS guide 3.86).
- **Graduation::step():** loads the transcript by `id_registrasi_mahasiswa` when the student identity is available, then computes completeness via the new private `checkTranskripCompleteness()` helper.
- **Wizard view:** new "2b. Kelengkapan Transkrip" card showing a green "Lengkap" / red "Belum lengkap: <reason>" badge. Soft warning only — Next stays enabled (matches the manual-verification design).

## Verification

Live-API probe confirmed:
- `GetTranskripMahasiswa` rows carry per-course final grades (`nilai_angka` / `nilai_huruf` / `nilai_indeks`) and have **no** `id_jenis_mata_kuliah` type flag.
- `GetAktivitasKuliahMahasiswa` is a per-semester summary (IPK / sks_total), not per-course grades.
- The thesis/skripsi course is therefore detected by course name; this institution names it `Skripsi` (also `THESIS`), and the detection pattern `/skripsi|tugas akhir|thesis|disertasi/i` matches it.
- NPM `202010087` (MUH ANDY RIZALDI) has 52 graded courses but no `Skripsi` row — the check correctly flags the thesis as not yet entered.

## Test plan

- [ ] Open the graduation wizard for a student; confirm the "2b. Kelengkapan Transkrip" card appears.
- [ ] With a thesis grade present → green "Lengkap".
- [ ] With no thesis grade → red "Belum lengkap: ..." and Next remains enabled.
- [ ] Local CI: `php -l`, `php-cs-fixer`, `phpunit` (36/69), `npm run build` — all green.

Fixes #67
