### PR TITLE
feat: add per-student detail page (ENH-021, #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ _None yet._
 - **PISN graduation pre-submit preview:** consolidated preview page (`/graduation/preview`) listing all verified students' graduation data before Neo Feeder submission, with explicit "Kirim ke Neo Feeder" confirmation — ENH-019, #64
 - **PISN graduation cancel session:** "Batalkan sesi" button on the upload page that clears the wizard progress cache and resume cookie, returning to a fresh upload form without waiting for the 24h TTL — ENH-023, #76
 - **PISN graduation transcript completeness check:** the graduation wizard loads each student's transcript (GetTranskripMahasiswa) and shows a "Kelengkapan Transkrip" card with a green "Lengkap" / red "Belum lengkap" badge when the thesis/skripsi grade is missing (soft warning, Next stays enabled) — ENH-020, #67
+- **Per-student detail page (ENH-021, #66):** new `GET /mahasiswa/detail/(:any)` → `Mahasiswa::detail()` renders a single student's full biodata record (all columns from `GetBiodataMahasiswa`) read-only, with a "Detail" button added to each row in the Mahasiswa list. Reuses the `fetchBiodata($id)` single-record fetch shared with `edit()`.
 
 ### Changed
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -27,6 +27,7 @@ $routes->get('mahasiswa-lulus-do', 'MahasiswaLulusDo::index');
  * --------------------------------------------------------------------
  */
 $routes->get('mahasiswa/edit/(:any)', 'Mahasiswa::edit/$1');
+$routes->get('mahasiswa/detail/(:any)', 'Mahasiswa::detail/$1');
 $routes->post('mahasiswa/edit/(:any)', 'Mahasiswa::editPost/$1');
 $routes->post('mahasiswa/delete/(:any)', 'Mahasiswa::delete/$1');
 $routes->get('aktivitas-kuliah/edit/(:any)/(:any)', 'AktivitasKuliah::edit/$1/$2');

--- a/app/Controllers/Mahasiswa.php
+++ b/app/Controllers/Mahasiswa.php
@@ -45,20 +45,9 @@ class Mahasiswa extends BaseController
     {
         $username = service('auth')->getCurrentUser();
         $row = null;
-        $token = session('auth.token');
         $error = null;
-
-        if ($token !== null && $id !== null) {
-            $idSafe = str_replace("'", "\'", (string) $id);
-            $response = service('neoFeeder')->getBiodataMahasiswa($token, [
-                'filter' => "id_mahasiswa='{$idSafe}'",
-                'limit'  => 1,
-            ]);
-            if (($response['error_code'] ?? -1) === 0 && !empty($response['data'])) {
-                $row = $response['data'][0];
-            } else {
-                $error = $response['error_msg'] ?? 'Gagal memuat data mahasiswa.';
-            }
+        if ($id !== null) {
+            ['row' => $row, 'error' => $error] = $this->fetchBiodata((string) $id);
         }
 
         return view('layout/header', ['username' => $username, 'title' => 'Edit Mahasiswa'])
@@ -70,6 +59,56 @@ class Mahasiswa extends BaseController
                 'id'       => $id,
             ])
             . view('layout/footer');
+    }
+
+    /**
+     * GET /mahasiswa/detail/(:any) — read-only single-student detail (ENH-021).
+     */
+    public function detail($id = null)
+    {
+        $username = service('auth')->getCurrentUser();
+        $row = null;
+        $error = null;
+        if ($id !== null) {
+            ['row' => $row, 'error' => $error] = $this->fetchBiodata((string) $id);
+        }
+
+        return view('layout/header', ['username' => $username, 'title' => 'Detail Mahasiswa'])
+            . view('layout/sidebar', ['username' => $username])
+            . view('mahasiswa/detail', [
+                'username' => $username,
+                'row'      => $row,
+                'error'    => $error,
+                'id'       => $id,
+            ])
+            . view('layout/footer');
+    }
+
+    /**
+     * Fetches a single student's full biodata by id_mahasiswa via GetBiodataMahasiswa.
+     *
+     * @return array{row:mixed|null, error:string|null}
+     */
+    private function fetchBiodata(string $id): array
+    {
+        $token = session('auth.token');
+        $row = null;
+        $error = null;
+
+        if ($token !== null) {
+            $idSafe = str_replace("'", "\'", $id);
+            $response = service('neoFeeder')->getBiodataMahasiswa($token, [
+                'filter' => "id_mahasiswa='{$idSafe}'",
+                'limit'  => 1,
+            ]);
+            if (($response['error_code'] ?? -1) === 0 && !empty($response['data'])) {
+                $row = $response['data'][0];
+            } else {
+                $error = $response['error_msg'] ?? 'Gagal memuat data mahasiswa.';
+            }
+        }
+
+        return ['row' => $row, 'error' => $error];
     }
 
     public function editPost($id = null)

--- a/app/Views/mahasiswa/detail.php
+++ b/app/Views/mahasiswa/detail.php
@@ -1,0 +1,54 @@
+<div class="app-content-header">
+    <div class="container-fluid">
+        <div class="row mb-2">
+            <div class="col-sm-6">
+                <h3 class="m-0">Detail Mahasiswa</h3>
+            </div>
+            <div class="col-sm-6">
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb float-sm-end">
+                        <li class="breadcrumb-item"><a href="<?= base_url('dashboard') ?>">Home</a></li>
+                        <li class="breadcrumb-item"><a href="<?= base_url('mahasiswa') ?>">Daftar Mahasiswa</a></li>
+                        <li class="breadcrumb-item active">Detail</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="app-content">
+    <div class="container-fluid">
+
+        <?php if ($error): ?>
+            <div class="alert alert-danger alert-dismissible">
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                <i class="fas fa-times-circle"></i> <?= esc($error) ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($row === null): ?>
+            <div class="alert alert-warning">Data tidak ditemukan.</div>
+        <?php else: ?>
+            <div class="card">
+                <div class="card-body">
+                    <table class="table table-bordered table-striped">
+                        <tbody>
+                            <?php foreach ($row as $col => $val): ?>
+                                <tr>
+                                    <th style="width:30%"><?= esc($col) ?></th>
+                                    <td><?= esc($val) ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="card-footer">
+                    <a href="<?= base_url('mahasiswa') ?>" class="btn btn-secondary">
+                        <i class="fas fa-arrow-left"></i> Kembali
+                    </a>
+                </div>
+            </div>
+        <?php endif; ?>
+
+    </div>
+</div>

--- a/app/Views/mahasiswa/index.php
+++ b/app/Views/mahasiswa/index.php
@@ -68,6 +68,7 @@
                                         <tr>
                                             <?php foreach ($row as $cell): ?><td><?= esc($cell) ?></td><?php endforeach; ?>
                                             <td>
+                                                <a href="<?= base_url('mahasiswa/detail/' . esc($row['id_mahasiswa'])) ?>" class="btn btn-sm btn-info">Detail</a>
                                                 <a href="<?= base_url('mahasiswa/edit/' . esc($row['id_mahasiswa'])) ?>" class="btn btn-sm btn-warning">Edit</a>
                                                 <form method="post" action="<?= base_url('mahasiswa/delete/' . esc($row['id_mahasiswa'])) ?>" style="display:inline">
                                                     <?= csrf_field() ?>

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -340,15 +340,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** Edit/Delete on Daftar Mahasiswa and Aktivitas Kuliah Mahasiswa now open the correct record instead of "Data tidak ditemukan."; the edit form is prefilled and Delete resolves the primary key correctly.
 
 ### ENH-021 — Per-student detail page
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #66
 - **Recorded:** 2026-08-27 23:35
-- **Implemented:** `—`
+- **Implemented:** `2026-08-28 17:15`
 - **Problem:** The menu tables hide several columns because the dataset is large (Mahasiswa ~25k, Aktivitas Kuliah ~222k rows). There is no way to open a single student and see the full detail.
 - **Possible Fix:** Add a detail page (route + view) that selects one student (by `id_mahasiswa` / by NIM) and renders all columns returned by the relevant Neo Feeder Get call, reusing the existing menu service methods.
 - **Actual Fix:** Add a per-student detail page using `getBiodataMahasiswa` (by `id_mahasiswa`, WS 3.7) and `getDetailPerkuliahanMahasiswa` (by composite key, WS 3.128) instead of the list endpoints — reusing the same single-record fetch the BUG-001 fix introduces. New route + view rendering all returned columns.
-- **Actual Implemented:** `—`
-- **Changes:** `—`
+- **Actual Implemented:** Added `GET mahasiswa/detail/(:any)` → `Mahasiswa::detail()` reusing the `getBiodataMahasiswa` single-record fetch (extracted into a private `fetchBiodata($id)` helper shared with `edit()`), mirroring the BUG-001 route pattern. New `app/Views/mahasiswa/detail.php` renders every returned column read-only; `mahasiswa/index.php` adds a "Detail" button. The `getDetailPerkuliahanMahasiswa` academic-history section was deferred (core-only scope per user decision 2026-08-28).
+- **Changes:** Admins can open a single student's full biodata record from the Mahasiswa list and see all columns (including those not shown in the table) without entering edit mode.
 
 ### ENH-022 — Pagination and general UI/UX refinements
 - **Status:** `verified`


### PR DESCRIPTION
## Summary
- Add a per-student detail page (ENH-021, #66): `GET /mahasiswa/detail/(:any)` → `Mahasiswa::detail()` renders a single student's full biodata record (all columns from `GetBiodataMahasiswa`) read-only.
- Each row in the Mahasiswa list now has a "Detail" button linking to the detail page.
- Extracted the single-record `getBiodataMahasiswa` fetch into a private `fetchBiodata($id)` helper shared by `detail()` and `edit()` (DRY, reuses the BUG-001 fix pattern).
- Core-only scope; the optional `getDetailPerkuliahanMahasiswa` academic-history section was deferred per user decision.

## Changes
- `app/Config/Routes.php`: add `mahasiswa/detail/(:any)` route (mirrors `mahasiswa/edit/(:any)`).
- `app/Controllers/Mahasiswa.php`: add `detail()` + private `fetchBiodata()`; `edit()` now uses the helper.
- `app/Views/mahasiswa/detail.php`: new read-only full-record view.
- `app/Views/mahasiswa/index.php`: add "Detail" button per row.
- `docs/IMPROVEMENTS.md` / `CHANGELOG.md`: tracker + changelog.

## Checklist
- [x] Route + controller + view implemented
- [x] `edit()` behavior preserved (shares fetch helper)
- [x] `php -l` / `php-cs-fixer` / `phpunit` (36/69) / `npm run build` green
- [x] Issue #66 OPEN at commit time
- [x] No schema assumption (detail renders `$row` dynamically)

Fixes #66
