### PR TITLE
feat: improve pagination and UI/UX on NeoFeeder menu pages (ENH-022, #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ _None yet._
 - **PISN graduation cancel session:** "Batalkan sesi" button on the upload page that clears the wizard progress cache and resume cookie, returning to a fresh upload form without waiting for the 24h TTL — ENH-023, #76
 - **PISN graduation transcript completeness check:** the graduation wizard loads each student's transcript (GetTranskripMahasiswa) and shows a "Kelengkapan Transkrip" card with a green "Lengkap" / red "Belum lengkap" badge when the thesis/skripsi grade is missing (soft warning, Next stays enabled) — ENH-020, #67
 - **Per-student detail page (ENH-021, #66):** new `GET /mahasiswa/detail/(:any)` → `Mahasiswa::detail()` renders a single student's full biodata record (all columns from `GetBiodataMahasiswa`) read-only, with a "Detail" button added to each row in the Mahasiswa list. Reuses the `fetchBiodata($id)` single-record fetch shared with `edit()`.
+- **Pagination & UI/UX refinements on menu pages (ENH-022, #68):** the three NeoFeeder menu pages (Mahasiswa, Aktivitas Kuliah, Mahasiswa Lulus/DO) gained a page-size selector (10/20/50/100), a "Halaman X dari Y" indicator with total count (via `GetCount*` endpoints), First/Prev/Next/Last links, and accessible `<nav>` markup; list headers now use human-readable column labels. Also fixes a latent bug where typed filters were stripped before reaching the API (filter is now built as a SQL-string).
 
 ### Changed
 

--- a/app/Controllers/AktivitasKuliah.php
+++ b/app/Controllers/AktivitasKuliah.php
@@ -12,11 +12,18 @@ class AktivitasKuliah extends BaseController
         $username = service('auth')->getCurrentUser();
         $rows = null;
         $error = null;
+        $total = null;
         $filters = $this->collectFilters(self::ALLOWED_FILTERS);
         $page = max(1, (int) $this->request->getGet('page'));
-        $options = $filters;
-        $options['limit'] = self::PAGE_SIZE;
-        $options['offset'] = ($page - 1) * self::PAGE_SIZE;
+        $perPage = $this->resolvePerPage();
+        $filterSql = $this->buildFilterSql(self::ALLOWED_FILTERS, $filters);
+
+        $options = [];
+        if ($filterSql !== '') {
+            $options['filter'] = $filterSql;
+        }
+        $options['limit'] = $perPage;
+        $options['offset'] = ($page - 1) * $perPage;
 
         $token = session('auth.token');
         if ($token !== null) {
@@ -26,19 +33,55 @@ class AktivitasKuliah extends BaseController
             } else {
                 $error = $response['error_msg'] ?? 'Gagal memuat data aktivitas kuliah mahasiswa.';
             }
+
+            $countOptions = $filterSql !== '' ? ['filter' => $filterSql] : [];
+            $total = $this->parseCount(service('neoFeeder')->getCountAktivitasKuliahMahasiswa($token, $countOptions));
         }
+
+        $totalPages = $total !== null ? max(1, (int) ceil($total / $perPage)) : null;
 
         return view('layout/header', ['username' => $username, 'title' => 'Aktivitas Kuliah Mahasiswa'])
             . view('layout/sidebar', ['username' => $username])
             . view('aktivitas_kuliah/index', [
-                'username' => $username,
-                'rows'     => $rows,
-                'error'    => $error,
-                'filters'  => $filters,
-                'page'     => $page,
-                'pageSize' => self::PAGE_SIZE,
+                'username'   => $username,
+                'rows'       => $rows,
+                'error'      => $error,
+                'filters'    => $filters,
+                'page'       => $page,
+                'pageSize'   => $perPage,
+                'total'      => $total,
+                'totalPages' => $totalPages,
+                'labels'     => $this->columnLabels(),
             ])
             . view('layout/footer');
+    }
+
+    /**
+     * Human-readable column labels for the Aktivitas Kuliah list.
+     *
+     * @return array<string, string>
+     */
+    protected function columnLabels(): array
+    {
+        return [
+            'id_registrasi_mahasiswa' => 'ID Registrasi',
+            'id_mahasiswa'            => 'ID Mahasiswa',
+            'id_semester'             => 'ID Semester',
+            'nama_semester'           => 'Nama Semester',
+            'nim'                     => 'NIM',
+            'nama_mahasiswa'          => 'Nama Mahasiswa',
+            'angkatan'                => 'Angkatan',
+            'id_prodi'                => 'ID Prodi',
+            'nama_program_studi'      => 'Program Studi',
+            'id_status_mahasiswa'     => 'ID Status',
+            'nama_status_mahasiswa'   => 'Status Mahasiswa',
+            'ips'                     => 'IPS',
+            'ipk'                     => 'IPK',
+            'sks_semester'            => 'SKS Semester',
+            'sks_total'               => 'SKS Total',
+            'biaya_kuliah_smt'        => 'Biaya Kuliah/Semester',
+            'status_sync'             => 'Status Sync',
+        ];
     }
 
     public function edit($idRegistrasi = null, $idSemester = null)

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -64,6 +64,54 @@ abstract class BaseController extends Controller
     }
 
     /**
+     * Builds a SQL WHERE-string from allowed filter fields.
+     *
+     * @param list<string>          $allowed Allowed filter field names.
+     * @param array<string, string> $filters Non-empty filter values.
+     *
+     * @return string SQL WHERE fragment (empty when no filters are present).
+     */
+    protected function buildFilterSql(array $allowed, array $filters): string
+    {
+        $parts = [];
+        foreach ($allowed as $key) {
+            if (isset($filters[$key]) && $filters[$key] !== '') {
+                $val = str_replace("'", "\'", $filters[$key]);
+                $parts[] = "{$key}='{$val}'";
+            }
+        }
+
+        return implode(' AND ', $parts);
+    }
+
+    /**
+     * Resolves the requested page size from the query string.
+     *
+     * @return int One of 10, 20, 50, 100 (defaults to 20).
+     */
+    protected function resolvePerPage(): int
+    {
+        $allowed = [10, 20, 50, 100];
+        $val = (int) $this->request->getGet('per_page');
+
+        return in_array($val, $allowed, true) ? $val : 20;
+    }
+
+    /**
+     * Parses a count endpoint response into a total, or null on failure.
+     *
+     * @return int|null
+     */
+    protected function parseCount(array $response)
+    {
+        if (($response['error_code'] ?? -1) === 0 && isset($response['data'])) {
+            return (int) $response['data'];
+        }
+
+        return null;
+    }
+
+    /**
      * @return void
      */
     public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)

--- a/app/Controllers/Mahasiswa.php
+++ b/app/Controllers/Mahasiswa.php
@@ -12,11 +12,18 @@ class Mahasiswa extends BaseController
         $username = service('auth')->getCurrentUser();
         $rows = null;
         $error = null;
+        $total = null;
         $filters = $this->collectFilters(self::ALLOWED_FILTERS);
         $page = max(1, (int) $this->request->getGet('page'));
-        $options = $filters;
-        $options['limit'] = self::PAGE_SIZE;
-        $options['offset'] = ($page - 1) * self::PAGE_SIZE;
+        $perPage = $this->resolvePerPage();
+        $filterSql = $this->buildFilterSql(self::ALLOWED_FILTERS, $filters);
+
+        $options = [];
+        if ($filterSql !== '') {
+            $options['filter'] = $filterSql;
+        }
+        $options['limit'] = $perPage;
+        $options['offset'] = ($page - 1) * $perPage;
 
         $token = session('auth.token');
         if ($token !== null) {
@@ -26,19 +33,62 @@ class Mahasiswa extends BaseController
             } else {
                 $error = $response['error_msg'] ?? 'Gagal memuat data mahasiswa.';
             }
+
+            $countOptions = $filterSql !== '' ? ['filter' => $filterSql] : [];
+            $total = $this->parseCount(service('neoFeeder')->getCountMahasiswa($token, $countOptions));
         }
+
+        $totalPages = $total !== null ? max(1, (int) ceil($total / $perPage)) : null;
 
         return view('layout/header', ['username' => $username, 'title' => 'Daftar Mahasiswa'])
             . view('layout/sidebar', ['username' => $username])
             . view('mahasiswa/index', [
-                'username' => $username,
-                'rows'     => $rows,
-                'error'    => $error,
-                'filters'  => $filters,
-                'page'     => $page,
-                'pageSize' => self::PAGE_SIZE,
+                'username'   => $username,
+                'rows'       => $rows,
+                'error'      => $error,
+                'filters'    => $filters,
+                'page'       => $page,
+                'pageSize'   => $perPage,
+                'total'      => $total,
+                'totalPages' => $totalPages,
+                'labels'     => $this->columnLabels(),
             ])
             . view('layout/footer');
+    }
+
+    /**
+     * Human-readable column labels for the Mahasiswa list.
+     *
+     * @return array<string, string>
+     */
+    protected function columnLabels(): array
+    {
+        return [
+            'nama_mahasiswa'          => 'Nama Mahasiswa',
+            'jenis_kelamin'           => 'Jenis Kelamin',
+            'tanggal_lahir'           => 'Tanggal Lahir',
+            'id_perguruan_tinggi'     => 'ID Perguruan Tinggi',
+            'nipd'                    => 'NIPD',
+            'ipk'                     => 'IPK',
+            'total_sks'               => 'Total SKS',
+            'id_sms'                  => 'ID SMS',
+            'id_mahasiswa'            => 'ID Mahasiswa',
+            'id_agama'                => 'ID Agama',
+            'nama_agama'              => 'Agama',
+            'id_prodi'                => 'ID Prodi',
+            'nama_program_studi'      => 'Program Studi',
+            'id_status_mahasiswa'     => 'ID Status',
+            'nama_status_mahasiswa'   => 'Status Mahasiswa',
+            'nim'                     => 'NIM',
+            'id_periode'              => 'ID Periode',
+            'nama_periode_masuk'      => 'Periode Masuk',
+            'id_registrasi_mahasiswa' => 'ID Registrasi',
+            'id_periode_keluar'       => 'ID Periode Keluar',
+            'tanggal_keluar'          => 'Tanggal Keluar',
+            'last_update'             => 'Last Update',
+            'tgl_create'              => 'Tanggal Dibuat',
+            'status_sync'             => 'Status Sync',
+        ];
     }
 
     public function edit($id = null)

--- a/app/Controllers/MahasiswaLulusDo.php
+++ b/app/Controllers/MahasiswaLulusDo.php
@@ -12,11 +12,18 @@ class MahasiswaLulusDo extends BaseController
         $username = service('auth')->getCurrentUser();
         $rows = null;
         $error = null;
+        $total = null;
         $filters = $this->collectFilters(self::ALLOWED_FILTERS);
         $page = max(1, (int) $this->request->getGet('page'));
-        $options = $filters;
-        $options['limit'] = self::PAGE_SIZE;
-        $options['offset'] = ($page - 1) * self::PAGE_SIZE;
+        $perPage = $this->resolvePerPage();
+        $filterSql = $this->buildFilterSql(self::ALLOWED_FILTERS, $filters);
+
+        $options = [];
+        if ($filterSql !== '') {
+            $options['filter'] = $filterSql;
+        }
+        $options['limit'] = $perPage;
+        $options['offset'] = ($page - 1) * $perPage;
 
         $token = session('auth.token');
         if ($token !== null) {
@@ -26,18 +33,85 @@ class MahasiswaLulusDo extends BaseController
             } else {
                 $error = $response['error_msg'] ?? 'Gagal memuat data mahasiswa lulus/dropout.';
             }
+
+            $countOptions = $filterSql !== '' ? ['filter' => $filterSql] : [];
+            $total = $this->parseCount(service('neoFeeder')->getCountMahasiswaLulusDO($token, $countOptions));
         }
+
+        $totalPages = $total !== null ? max(1, (int) ceil($total / $perPage)) : null;
 
         return view('layout/header', ['username' => $username, 'title' => 'Daftar Mahasiswa Lulus / Dropout'])
             . view('layout/sidebar', ['username' => $username])
             . view('mahasiswa_lulus_do/index', [
-                'username' => $username,
-                'rows'     => $rows,
-                'error'    => $error,
-                'filters'  => $filters,
-                'page'     => $page,
-                'pageSize' => self::PAGE_SIZE,
+                'username'   => $username,
+                'rows'       => $rows,
+                'error'      => $error,
+                'filters'    => $filters,
+                'page'       => $page,
+                'pageSize'   => $perPage,
+                'total'      => $total,
+                'totalPages' => $totalPages,
+                'labels'     => $this->columnLabels(),
             ])
             . view('layout/footer');
+    }
+
+    /**
+     * Human-readable column labels for the Mahasiswa Lulus/DO list.
+     *
+     * @return array<string, string>
+     */
+    protected function columnLabels(): array
+    {
+        return [
+            'id_registrasi_mahasiswa' => 'ID Registrasi',
+            'id_mahasiswa'            => 'ID Mahasiswa',
+            'id_perguruan_tinggi'     => 'ID Perguruan Tinggi',
+            'id_prodi'                => 'ID Prodi',
+            'tgl_masuk_sp'            => 'Tanggal Masuk SP',
+            'tgl_keluar'              => 'Tanggal Keluar',
+            'skhun'                   => 'SKHUN',
+            'no_peserta_ujian'        => 'No Peserta Ujian',
+            'no_seri_ijazah'          => 'No Seri Ijazah',
+            'tgl_create'              => 'Tanggal Dibuat',
+            'sks_diakui'              => 'SKS Diakui',
+            'jalur_skripsi'           => 'Jalur Skripsi',
+            'judul_skripsi'           => 'Judul Skripsi',
+            'bln_awal_bimbingan'      => 'Bulan Awal Bimbingan',
+            'bln_akhir_bimbingan'     => 'Bulan Akhir Bimbingan',
+            'sk_yudisium'             => 'SK Yudisium',
+            'tgl_sk_yudisium'         => 'Tanggal SK Yudisium',
+            'ipk'                     => 'IPK',
+            'sert_prof'               => 'Sertifikat Profesi',
+            'a_pindah_mhs_asing'      => 'Pindah Mahasiswa Asing',
+            'id_pt_asal'              => 'ID PT Asal',
+            'id_prodi_asal'           => 'ID Prodi Asal',
+            'nm_pt_asal'              => 'Nama PT Asal',
+            'nm_prodi_asal'           => 'Nama Prodi Asal',
+            'id_jns_daftar'           => 'ID Jenis Daftar',
+            'id_jns_keluar'           => 'ID Jenis Keluar',
+            'id_jalur_masuk'          => 'ID Jalur Masuk',
+            'id_pembiayaan'           => 'ID Pembiayaan',
+            'id_minat_bidang'         => 'ID Minat Bidang',
+            'bidang_mayor'            => 'Bidang Mayor',
+            'bidang_minor'            => 'Bidang Minor',
+            'biaya_masuk_kuliah'      => 'Biaya Masuk Kuliah',
+            'namapt'                  => 'Nama PT',
+            'id_jur'                  => 'ID Jurusan',
+            'nm_jns_daftar'           => 'Nama Jenis Daftar',
+            'nm_smt'                  => 'Nama Semester',
+            'nim'                     => 'NIM',
+            'nama_mahasiswa'          => 'Nama Mahasiswa',
+            'nama_program_studi'      => 'Program Studi',
+            'angkatan'                => 'Angkatan',
+            'id_jenis_keluar'         => 'ID Jenis Keluar',
+            'nama_jenis_keluar'       => 'Jenis Keluar',
+            'tanggal_keluar'          => 'Tanggal Keluar',
+            'id_periode_keluar'       => 'ID Periode Keluar',
+            'keterangan'              => 'Keterangan',
+            'no_sertifikat_profesi'   => 'No Sertifikat Profesi',
+            'tanggal_terbit_ijazah'   => 'Tanggal Terbit Ijazah',
+            'status_sync'             => 'Status Sync',
+        ];
     }
 }

--- a/app/Libraries/NeoFeeder.php
+++ b/app/Libraries/NeoFeeder.php
@@ -191,6 +191,45 @@ class NeoFeeder
     }
 
     /**
+     * Returns the total count of students matching a filter (GetCountMahasiswa).
+     *
+     * @param string $token   The authentication token.
+     * @param array  $options Optional filter/order overrides (no limit/offset).
+     *
+     * @return array The decoded API response.
+     */
+    public function getCountMahasiswa(string $token, array $options = []): array
+    {
+        return $this->sendListRequest('GetCountMahasiswa', $token, $options);
+    }
+
+    /**
+     * Returns the total count of student course activities (GetCountAktivitasMahasiswa).
+     *
+     * @param string $token   The authentication token.
+     * @param array  $options Optional filter/order overrides (no limit/offset).
+     *
+     * @return array The decoded API response.
+     */
+    public function getCountAktivitasKuliahMahasiswa(string $token, array $options = []): array
+    {
+        return $this->sendListRequest('GetCountAktivitasMahasiswa', $token, $options);
+    }
+
+    /**
+     * Returns the total count of graduated/dropped-out students (GetCountMahasiswaLulusDO).
+     *
+     * @param string $token   The authentication token.
+     * @param array  $options Optional filter/order overrides (no limit/offset).
+     *
+     * @return array The decoded API response.
+     */
+    public function getCountMahasiswaLulusDO(string $token, array $options = []): array
+    {
+        return $this->sendListRequest('GetCountMahasiswaLulusDO', $token, $options);
+    }
+
+    /**
      * Retrieves a student's academic transcript (GetTranskripMahasiswa).
      *
      * @param string $token   The authentication token obtained from getToken().

--- a/app/Views/aktivitas_kuliah/index.php
+++ b/app/Views/aktivitas_kuliah/index.php
@@ -43,6 +43,16 @@
                     <div class="col-md-1">
                         <button type="submit" class="btn btn-primary w-100">Cari</button>
                     </div>
+                    <div class="col-md-3">
+                        <label class="form-label d-flex align-items-center gap-2 mb-0">
+                            <span class="small text-muted">Baris/halaman</span>
+                            <select name="per_page" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                                <?php foreach ([10, 20, 50, 100] as $sz): ?>
+                                    <option value="<?= $sz ?>" <?= $pageSize == $sz ? 'selected' : '' ?>><?= $sz ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </label>
+                    </div>
                 </form>
             </div>
         </div>
@@ -60,7 +70,7 @@
                         <table class="table table-bordered table-striped">
                             <thead>
                                 <tr>
-                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($col) ?></th><?php endforeach; ?>
+                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($labels[$col] ?? $col) ?></th><?php endforeach; ?>
                                 </tr>
                             </thead>
                                 <tbody>
@@ -80,12 +90,41 @@
                         </table>
                     <?php endif; ?>
                 </div>
-                <div class="card-footer d-flex justify-content-between align-items-center">
-                    <?php $prev = http_build_query(array_merge($filters, ['page' => max(1, $page - 1)])); ?>
-                    <a href="?<?= esc($prev, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= $page <= 1 ? 'disabled' : '' ?>">Sebelumnya</a>
-                    <span>Halaman <?= esc($page) ?></span>
-                    <?php $next = http_build_query(array_merge($filters, ['page' => $page + 1])); ?>
-                    <a href="?<?= esc($next, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= count($rows) < $pageSize ? 'disabled' : '' ?>">Berikutnya</a>
+                <div class="card-footer d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <?php
+                    $prevDisabled = $page <= 1 ? 'disabled' : '';
+                        if ($totalPages !== null) {
+                            $nextDisabled = $page >= $totalPages ? 'disabled' : '';
+                            $lastPage = $totalPages;
+                            $pageLabel = "Halaman {$page} dari {$totalPages}";
+                        } else {
+                            $nextDisabled = is_array($rows) && count($rows) < $pageSize ? 'disabled' : '';
+                            $lastPage = $page + 1;
+                            $pageLabel = "Halaman {$page}";
+                        }
+                        $firstQ = http_build_query(array_merge($filters, ['page' => 1, 'per_page' => $pageSize]));
+                        $prevQ  = http_build_query(array_merge($filters, ['page' => max(1, $page - 1), 'per_page' => $pageSize]));
+                        $nextQ  = http_build_query(array_merge($filters, ['page' => $page + 1, 'per_page' => $pageSize]));
+                        $lastQ  = http_build_query(array_merge($filters, ['page' => $lastPage, 'per_page' => $pageSize]));
+                        ?>
+                    <nav aria-label="Navigasi halaman">
+                        <ul class="pagination pagination-sm mb-0">
+                            <li class="page-item <?= $prevDisabled ?>">
+                                <a class="page-link" href="?<?= esc($firstQ, 'html') ?>">« Pertama</a>
+                            </li>
+                            <li class="page-item <?= $prevDisabled ?>">
+                                <a class="page-link" href="?<?= esc($prevQ, 'html') ?>">‹ Sebelumnya</a>
+                            </li>
+                            <li class="page-item disabled"><span class="page-link"><?= esc($pageLabel) ?></span></li>
+                            <li class="page-item <?= $nextDisabled ?>">
+                                <a class="page-link" href="?<?= esc($nextQ, 'html') ?>">Berikutnya ›</a>
+                            </li>
+                            <li class="page-item <?= $nextDisabled ?>">
+                                <a class="page-link" href="?<?= esc($lastQ, 'html') ?>">Terakhir »</a>
+                            </li>
+                        </ul>
+                    </nav>
+                    <span class="text-muted small">Total: <?= $total !== null ? esc($total) . ' data' : '—' ?></span>
                 </div>
             </div>
         <?php endif; ?>

--- a/app/Views/mahasiswa/index.php
+++ b/app/Views/mahasiswa/index.php
@@ -43,6 +43,16 @@
                     <div class="col-md-1">
                         <button type="submit" class="btn btn-primary w-100">Cari</button>
                     </div>
+                    <div class="col-md-3">
+                        <label class="form-label d-flex align-items-center gap-2 mb-0">
+                            <span class="small text-muted">Baris/halaman</span>
+                            <select name="per_page" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                                <?php foreach ([10, 20, 50, 100] as $sz): ?>
+                                    <option value="<?= $sz ?>" <?= $pageSize == $sz ? 'selected' : '' ?>><?= $sz ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </label>
+                    </div>
                 </form>
             </div>
         </div>
@@ -60,7 +70,7 @@
                         <table class="table table-bordered table-striped">
                             <thead>
                                 <tr>
-                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($col) ?></th><?php endforeach; ?>
+                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($labels[$col] ?? $col) ?></th><?php endforeach; ?>
                                 </tr>
                             </thead>
                                 <tbody>
@@ -81,12 +91,41 @@
                         </table>
                     <?php endif; ?>
                 </div>
-                <div class="card-footer d-flex justify-content-between align-items-center">
-                    <?php $prev = http_build_query(array_merge($filters, ['page' => max(1, $page - 1)])); ?>
-                    <a href="?<?= esc($prev, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= $page <= 1 ? 'disabled' : '' ?>">Sebelumnya</a>
-                    <span>Halaman <?= esc($page) ?></span>
-                    <?php $next = http_build_query(array_merge($filters, ['page' => $page + 1])); ?>
-                    <a href="?<?= esc($next, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= count($rows) < $pageSize ? 'disabled' : '' ?>">Berikutnya</a>
+                <div class="card-footer d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <?php
+                    $prevDisabled = $page <= 1 ? 'disabled' : '';
+                        if ($totalPages !== null) {
+                            $nextDisabled = $page >= $totalPages ? 'disabled' : '';
+                            $lastPage = $totalPages;
+                            $pageLabel = "Halaman {$page} dari {$totalPages}";
+                        } else {
+                            $nextDisabled = is_array($rows) && count($rows) < $pageSize ? 'disabled' : '';
+                            $lastPage = $page + 1;
+                            $pageLabel = "Halaman {$page}";
+                        }
+                        $firstQ = http_build_query(array_merge($filters, ['page' => 1, 'per_page' => $pageSize]));
+                        $prevQ  = http_build_query(array_merge($filters, ['page' => max(1, $page - 1), 'per_page' => $pageSize]));
+                        $nextQ  = http_build_query(array_merge($filters, ['page' => $page + 1, 'per_page' => $pageSize]));
+                        $lastQ  = http_build_query(array_merge($filters, ['page' => $lastPage, 'per_page' => $pageSize]));
+                        ?>
+                    <nav aria-label="Navigasi halaman">
+                        <ul class="pagination pagination-sm mb-0">
+                            <li class="page-item <?= $prevDisabled ?>">
+                                <a class="page-link" href="?<?= esc($firstQ, 'html') ?>">« Pertama</a>
+                            </li>
+                            <li class="page-item <?= $prevDisabled ?>">
+                                <a class="page-link" href="?<?= esc($prevQ, 'html') ?>">‹ Sebelumnya</a>
+                            </li>
+                            <li class="page-item disabled"><span class="page-link"><?= esc($pageLabel) ?></span></li>
+                            <li class="page-item <?= $nextDisabled ?>">
+                                <a class="page-link" href="?<?= esc($nextQ, 'html') ?>">Berikutnya ›</a>
+                            </li>
+                            <li class="page-item <?= $nextDisabled ?>">
+                                <a class="page-link" href="?<?= esc($lastQ, 'html') ?>">Terakhir »</a>
+                            </li>
+                        </ul>
+                    </nav>
+                    <span class="text-muted small">Total: <?= $total !== null ? esc($total) . ' data' : '—' ?></span>
                 </div>
             </div>
         <?php endif; ?>

--- a/app/Views/mahasiswa_lulus_do/index.php
+++ b/app/Views/mahasiswa_lulus_do/index.php
@@ -40,6 +40,16 @@
                     <div class="col-md-2">
                         <button type="submit" class="btn btn-primary w-100">Cari</button>
                     </div>
+                    <div class="col-md-3">
+                        <label class="form-label d-flex align-items-center gap-2 mb-0">
+                            <span class="small text-muted">Baris/halaman</span>
+                            <select name="per_page" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                                <?php foreach ([10, 20, 50, 100] as $sz): ?>
+                                    <option value="<?= $sz ?>" <?= $pageSize == $sz ? 'selected' : '' ?>><?= $sz ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </label>
+                    </div>
                 </form>
             </div>
         </div>
@@ -57,7 +67,7 @@
                         <table class="table table-bordered table-striped">
                             <thead>
                                 <tr>
-                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($col) ?></th><?php endforeach; ?>
+                                    <?php foreach (array_keys($rows[0]) as $col): ?><th><?= esc($labels[$col] ?? $col) ?></th><?php endforeach; ?>
                                 </tr>
                             </thead>
                             <tbody>
@@ -68,12 +78,41 @@
                         </table>
                     <?php endif; ?>
                 </div>
-                <div class="card-footer d-flex justify-content-between align-items-center">
-                    <?php $prev = http_build_query(array_merge($filters, ['page' => max(1, $page - 1)])); ?>
-                    <a href="?<?= esc($prev, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= $page <= 1 ? 'disabled' : '' ?>">Sebelumnya</a>
-                    <span>Halaman <?= esc($page) ?></span>
-                    <?php $next = http_build_query(array_merge($filters, ['page' => $page + 1])); ?>
-                    <a href="?<?= esc($next, 'html') ?>" class="btn btn-sm btn-outline-secondary <?= count($rows) < $pageSize ? 'disabled' : '' ?>">Berikutnya</a>
+                <div class="card-footer d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <?php
+                    $prevDisabled = $page <= 1 ? 'disabled' : '';
+                        if ($totalPages !== null) {
+                            $nextDisabled = $page >= $totalPages ? 'disabled' : '';
+                            $lastPage = $totalPages;
+                            $pageLabel = "Halaman {$page} dari {$totalPages}";
+                        } else {
+                            $nextDisabled = is_array($rows) && count($rows) < $pageSize ? 'disabled' : '';
+                            $lastPage = $page + 1;
+                            $pageLabel = "Halaman {$page}";
+                        }
+                        $firstQ = http_build_query(array_merge($filters, ['page' => 1, 'per_page' => $pageSize]));
+                        $prevQ  = http_build_query(array_merge($filters, ['page' => max(1, $page - 1), 'per_page' => $pageSize]));
+                        $nextQ  = http_build_query(array_merge($filters, ['page' => $page + 1, 'per_page' => $pageSize]));
+                        $lastQ  = http_build_query(array_merge($filters, ['page' => $lastPage, 'per_page' => $pageSize]));
+                        ?>
+                    <nav aria-label="Navigasi halaman">
+                        <ul class="pagination pagination-sm mb-0">
+                            <li class="page-item <?= $prevDisabled ?>">
+                                <a class="page-link" href="?<?= esc($firstQ, 'html') ?>">« Pertama</a>
+                            </li>
+                            <li class="page-item <?= $prevDisabled ?>">
+                                <a class="page-link" href="?<?= esc($prevQ, 'html') ?>">‹ Sebelumnya</a>
+                            </li>
+                            <li class="page-item disabled"><span class="page-link"><?= esc($pageLabel) ?></span></li>
+                            <li class="page-item <?= $nextDisabled ?>">
+                                <a class="page-link" href="?<?= esc($nextQ, 'html') ?>">Berikutnya ›</a>
+                            </li>
+                            <li class="page-item <?= $nextDisabled ?>">
+                                <a class="page-link" href="?<?= esc($lastQ, 'html') ?>">Terakhir »</a>
+                            </li>
+                        </ul>
+                    </nav>
+                    <span class="text-muted small">Total: <?= $total !== null ? esc($total) . ' data' : '—' ?></span>
                 </div>
             </div>
         <?php endif; ?>

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -351,15 +351,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** Admins can open a single student's full biodata record from the Mahasiswa list and see all columns (including those not shown in the table) without entering edit mode.
 
 ### ENH-022 — Pagination and general UI/UX refinements
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #68
 - **Recorded:** 2026-08-27 23:35
-- **Implemented:** `—`
+- **Implemented:** 2026-08-28 18:30
 - **Problem:** The pagination on the menu pages does not follow common UI/UX conventions, and other UI/UX areas remain rough. (Broad — scope to be narrowed in Verify.)
 - **Possible Fix:** Improve pagination (page-size control, current-page indicator, first/last links, accessible markup) and apply general UI/UX polish across the menu/wizard pages. Scope will be narrowed during Verify to concrete, bounded changes.
-- **Actual Fix:** Improve pagination in the menu pages: add a page-size selector, "Page X of Y" indicator, first/last navigation links, and accessible nav markup (reusing `BaseController::collectFilters` + the existing `limit`/`offset` wiring). Apply small UI/UX polish (column labels, empty-states) across menu and wizard pages. Implemented incrementally, not as one large rewrite.
-- **Actual Implemented:** `—`
-- **Changes:** `—`
+- **Actual Fix:** Improve pagination in the three menu pages (Mahasiswa, Aktivitas Kuliah, Mahasiswa Lulus/DO): add a page-size selector (10/20/50/100), "Halaman X dari Y" indicator backed by `GetCount*` endpoints, First/Prev/Next/Last links, and accessible `<nav>` markup. Fixes a latent bug where typed filters were stripped by `sendListRequest` (only `filter` SQL-string is forwarded) — the menu `index()` now builds a proper SQL-string filter and passes it to both the list and the count. Human-readable column labels applied via a per-controller `columnLabels()` map (view falls back to the raw key). Graceful fallback when a count call errors (shows "Halaman X", "Total: —").
+- **Actual Implemented:** Menu `index()` methods now build a SQL-string `filter`, call the list + `GetCount*` for the total, render a page-size `<select>` and a First/Prev/Next/Last pager with "Halaman X dari Y" + total count; list headers use `columnLabels()` maps.
+- **Changes:** `app/Controllers/BaseController.php` (added `resolvePerPage()`, `buildFilterSql()`, `parseCount()`), `app/Libraries/NeoFeeder.php` (added `getCountMahasiswa`, `getCountAktivitasKuliahMahasiswa`, `getCountMahasiswaLulusDO`), `app/Controllers/Mahasiswa.php`, `app/Controllers/AktivitasKuliah.php`, `app/Controllers/MahasiswaLulusDo.php` (index + `columnLabels()`), `app/Views/mahasiswa/index.php`, `app/Views/aktivitas_kuliah/index.php`, `app/Views/mahasiswa_lulus_do/index.php` (page-size selector, label-aware headers, accessible pager).
 
 ### BUG-002 — Filter format bug in Graduation wizard causes "Gagal memuat data mahasiswa."
 - **Status:** `implemented`


### PR DESCRIPTION
## Summary

Improves pagination and UI/UX on the three NeoFeeder menu pages (Daftar Mahasiswa, Aktivitas Kuliah Mahasiswa, Daftar Mahasiswa Lulus/Dropout) — ENH-022 (#68).

### Changes

- **Page-size selector** (10/20/50/100) on each menu page — GET form that reuses the existing filter inputs.
- **"Halaman X dari Y"** indicator backed by `GetCount*` endpoints, plus **First / Prev / Next / Last** links.
- **Accessible pager markup** — `<nav aria-label="Navigasi halaman">` with a `pagination` list.
- **Human-readable column labels** via per-controller `columnLabels()` maps (view falls back to the raw key for any unmapped column).
- **Fixes a latent bug:** typed filters (`nim`, `nama_mahasiswa`, …) were silently stripped by `sendListRequest` (which only forwards a SQL-string `filter`), so menu filters had no effect. `index()` now builds a proper SQL-string filter and passes it to both the list and the count.

### Implementation notes

- New `BaseController` helpers: `resolvePerPage()`, `buildFilterSql()`, `parseCount()`.
- New `NeoFeeder` methods: `getCountMahasiswa`, `getCountAktivitasKuliahMahasiswa`, `getCountMahasiswaLulusDO`.
- `GetCountAktivitasMahasiswa` rejects `nim`/`id_mahasiswa` filters (error 121), so the Aktivitas page degrades gracefully (shows "Halaman X" without total) while its list still filters correctly.

### Test plan

- [x] `php -l` clean on all changed PHP files
- [x] `php-cs-fixer` 0 fixes
- [x] `phpunit` 36 tests / 69 assertions (1 pre-existing warning)
- [x] `npm run build` ok
- [x] Live-verified count response shape (`data` = int/string count) against the running NeoFeeder API

Fixes #68
