### PR TITLE
feat: hide UUID columns in graduation wizard (ENH-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ _None yet._
 
 ### Changed
 
+- **PISN graduation wizard:** hides every UUID-valued column in the identity and academic verification tables (detected by UUID pattern, including `id_registrasi_mahasiswa`, `id_mahasiswa`, `id_aktivitas_kuliah`, `id_perguruan_tinggi`, `id_sms`, `id_agama`, `id_prodi`, `id_status_mahasiswa`, `id_periode`, `id_periode_keluar`); the `id_semester` code and human-readable columns remain visible — ENH-001, #85
 - **Repo restructured to professional GitHub standard:** removed agent-only docs (`AGENTS.md`, `OPEN_ISSUES.md`, `DESIGN.md`, `CODING_STANDARDS.md`, `.memory/`); archived Sprint 1 issues to `docs/archived/`; added `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `SECURITY.md` (supported versions + disclosure policy), GitHub issue templates (bug report, feature request), and a release notes template (`.github/RELEASE_NOTES_TEMPLATE.md`); `CONTRIBUTING.md` now holds coding conventions + GitHub Flow workflow; LICENSE adds project copyright; all documentation translated to English
 - **Documentation shrinkage for model context:** `DESIGN.md` 1138→473 lines (removed Bootstrap 5 boilerplate, kept project-specific patterns only); `CODING_STANDARDS.md` 537→287 lines (trimmed general PHP knowledge); `OPEN_ISSUES.md` 295→54 lines (archived 9 done Sprint 1 items to `docs/archived/SPRINT1_ISSUES.md`)
 - **Documentation restructure:** `AGENTS.md` split into Golden Path (must-survive compression) + Reference sections; `CONTRIBUTING.md` deduplicated to human-focused content — lifecycle removed (delegated to AGENTS.md)

--- a/app/Controllers/Graduation.php
+++ b/app/Controllers/Graduation.php
@@ -226,6 +226,8 @@ class Graduation extends BaseController
             'transcript'   => $transcript,
             'completeness' => $completeness,
             'pisn'         => $pisn,
+            'uuidKeys'     => ['id_registrasi_mahasiswa', 'id_mahasiswa', 'id_aktivitas_kuliah'],
+            'uuidRegex'    => '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i',
             'error'        => $error,
             'isLast'       => ($idx === $total - 1),
             'saved'        => $student['saved'] ?? false,

--- a/app/Views/graduation/wizard.php
+++ b/app/Views/graduation/wizard.php
@@ -38,9 +38,12 @@
                     <?php else: ?>
                         <table class="table table-sm table-bordered w-auto">
                             <tbody>
-                                <?php foreach ($identity as $key => $value): ?>
-                                    <tr><th><?= esc($key) ?></th><td><?= esc($value) ?></td></tr>
-                                <?php endforeach; ?>
+                        <?php foreach ($identity as $key => $value): ?>
+                            <?php if (in_array($key, $uuidKeys, true) || (is_string($value) && preg_match($uuidRegex, $value))) {
+                                continue;
+                            } ?>
+                            <tr><th><?= esc($key) ?></th><td><?= esc($value) ?></td></tr>
+                        <?php endforeach; ?>
                             </tbody>
                         </table>
                     <?php endif; ?>
@@ -61,10 +64,20 @@
                     <?php else: ?>
                         <div class="table-responsive mb-2">
                             <table class="table table-sm table-bordered table-striped">
-                                <thead><tr><?php foreach (array_keys($academic[0]) as $col): ?><th><?= esc($col) ?></th><?php endforeach; ?></tr></thead>
+                                <?php
+                                $cols = [];
+                        foreach (array_keys($academic[0]) as $k) {
+                            $sample = $academic[0][$k] ?? '';
+                            if (in_array($k, $uuidKeys, true) || (is_string($sample) && preg_match($uuidRegex, $sample))) {
+                                continue;
+                            }
+                            $cols[] = $k;
+                        }
+                        ?>
+                                <thead><tr><?php foreach ($cols as $col): ?><th><?= esc($col) ?></th><?php endforeach; ?></tr></thead>
                                 <tbody>
                                     <?php foreach ($academic as $row): ?>
-                                        <tr><?php foreach ($row as $cell): ?><td><?= esc($cell) ?></td><?php endforeach; ?></tr>
+                                        <tr><?php foreach ($cols as $col): ?><td><?= esc($row[$col] ?? '') ?></td><?php endforeach; ?></tr>
                                     <?php endforeach; ?>
                                 </tbody>
                             </table>

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -77,15 +77,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 ## Active Items
 
 ### ENH-001 — Hide UUID/random-string ID columns in PISN Graduation verification step
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #85
 - **Recorded:** 2026-08-30 02:21
-- **Implemented:** —
+- **Implemented:** 2026-08-30 03:44
 - **Problem:** In `app/Views/graduation/wizard.php` the identity table (lines 41–43) and the academic table (lines 64–69) render every key returned by the Neo Feeder API, including columns whose values are random UUID strings (e.g. `id_registrasi_mahasiswa`, `id_mahasiswa`, `id_aktivitas_kuliah`). These columns are meaningless to the admin and clutter the verification UI. The same pattern exists in the Mahasiswa, Aktivitas Kuliah, and Mahasiswa Lulus-DO menus, but the current scope is PISN Graduation only.
 - **Possible Fix:** In `wizard.php`, suppress columns whose values are UUID/random strings from both the identity and academic tables. Keep functional, non-random columns such as `id_semester`. Implement an explicit allow/deny list of column keys to hide. Other menus stay out of scope for now.
 - **Actual Fix:** In `app/Views/graduation/wizard.php`, define a deny-list of column keys whose values are UUID/random strings and skip them when rendering both the identity table (lines 41–43) and the academic table (lines 64–69). Deny-list: `id_registrasi_mahasiswa`, `id_mahasiswa`, `id_aktivitas_kuliah` (plus any other UUID-valued `*_id` keys observed in the live response). Keep `id_semester` and all human-readable columns visible. Scope: PISN Graduation wizard only; other menus stay out of scope.
-- **Actual Implemented:** —
-- **Changes:** —
+- **Actual Implemented:** Every UUID-valued column is hidden from both wizard tables. `Graduation::step()` passes `$uuidKeys` (explicit deny-list `id_registrasi_mahasiswa`, `id_mahasiswa`, `id_aktivitas_kuliah`) and `$uuidRegex` (`/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i`) to `graduation/wizard`. The identity table skips a row whose key is in `$uuidKeys` or whose value matches `$uuidRegex`; the academic table builds visible columns by skipping any column whose sample value matches `$uuidRegex` (header + cells stay aligned). `id_semester` (code e.g. `20252`, not a UUID) and all human-readable columns remain. Verified live via Playwright: 0 UUID cells in the Identitas and Akademik tables.
+- **Changes:** `app/Controllers/Graduation.php` (pass `uuidKeys` + `uuidRegex` to `graduation/wizard`), `app/Views/graduation/wizard.php` (value-based UUID skip in identity + academic tables).
 
 ### ENH-002 — Sort academic table by id_semester ascending
 - **Status:** `verified`


### PR DESCRIPTION
## Summary

Hide the random-string/UUID identifier columns from the PISN graduation verification step. The identity and academic tables now auto-hide any column whose cell values are UUIDs (e.g. `id_registrasi_mahasiswa`, `id_mahasiswa`, `id_aktivitas_kuliah`, `id_perguruan_tinggi`, `id_sms`), so only meaningful, readable columns such as `id_semester` remain.

## Related issues

Fixes #85

## Checklist

- [x] `php -l` passes on all modified PHP files
- [ ] `npm run build` succeeds and committed assets are up to date (N/A - no asset changes)
- [ ] `php spark routes` shows correct new routes (N/A - no route changes)
- [x] `vendor/bin/php-cs-fixer fix` passes (no style violations)
- [x] `vendor/bin/phpunit` is green (if tests exist)
- [x] No debug code: `dd()`, `var_dump()`, `console.log()`, `print_r()`, `exit()`
- [ ] All user inputs validated server-side (N/A - no new user input)
- [ ] All POST forms include `csrf_field()` (N/A - no new POST form)
- [x] All HTML output uses `esc()`
- [x] No unrelated files changed
- [x] CHANGELOG updated if this is a user-facing change
- [x] Behaviour verified in the browser if UI changed

## Screenshot (if applicable)

## Notes for reviewers

UUID columns are detected by value (a UUID regex tested against cell values), not by a static key deny-list, so any future UUID-valued Neo Feeder column is hidden automatically while readable code columns like `id_semester` remain.