### PR TITLE
feat: sort academic table by semester ascending (ENH-002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ _None yet._
 - **Release process:** added step to update `app/Config/AppVersion.php` when releasing a new version
 - **Profil PT page:** redesigned layout with visual hierarchy — hero card `card-outline-primary` (name in `display-6` + accreditation badge, identity & legalitas info in `d-flex gap-4`), two `card-info h-100` cards side by side (Contact with clickable links + Address), `fa-fw` for aligned icons, equal-height via `d-flex flex-column` + `mt-auto`, `https://` prepended to website URL, Indonesian date format via `strtr()`, max width via `col-xxl-10`
 - **Dependencies:** bumped `admin-lte` from 4.1.0 to 4.8.4 (AdminLTE 4.x line — no breaking changes, backward-compatible HTML/CSS)
+- **PISN graduation wizard:** sorts the academic verification table (card 2) by `id_semester` ascending (oldest→newest), via API `order` plus a defensive `usort` fallback — ENH-002, #86
 
 ### Fixed
 

--- a/app/Controllers/Graduation.php
+++ b/app/Controllers/Graduation.php
@@ -192,10 +192,14 @@ class Graduation extends BaseController
 
             $acResp = $this->neoFeeder->getAktivitasKuliahMahasiswa($apiToken, [
                 'filter' => "nim='{$nimSafe}'",
+                'order'  => 'id_semester asc',
                 'limit'  => 50,
             ]);
             if (($acResp['error_code'] ?? -1) === 0 && isset($acResp['data'])) {
                 $academic = $acResp['data'];
+            }
+            if (is_array($academic)) {
+                usort($academic, fn ($a, $b) => strcmp($a['id_semester'] ?? '', $b['id_semester'] ?? ''));
             }
 
             if ($identity !== null && isset($identity['id_registrasi_mahasiswa'])) {

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -88,15 +88,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** —
 
 ### ENH-002 — Sort academic table by id_semester ascending
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #86
 - **Recorded:** 2026-08-30 02:21
-- **Implemented:** —
+- **Implemented:** 2026-08-30 04:08
 - **Problem:** `Graduation::step()` calls `getAktivitasKuliahMahasiswa` without an order parameter (`app/Controllers/Graduation.php:193–199`), so the academic table (card 2) displays rows in the raw API response order rather than chronological semester order, making the academic-history review hard to read.
 - **Possible Fix:** Sort the academic rows by `id_semester` ascending (20261 → 20262 …). Decide between a PHP `usort` on the returned array versus passing an `order` parameter to the API; confirm during verification which approach is reliable.
 - **Actual Fix:** In `Graduation::step()`, pass `order => 'id_semester asc'` to `getAktivitasKuliahMahasiswa` (`sendListRequest` already forwards `order`; `app/Libraries/NeoFeeder.php:142–152`). As a defensive fallback, apply a PHP `usort` by `id_semester` (string ascending) on the returned array in case the API does not honor the `order` parameter. Keep the `id_semester` column visible (used for sorting and display).
-- **Actual Implemented:** —
-- **Changes:** —
+- **Actual Implemented:** `Graduation::step()` now passes `order => 'id_semester asc'` to `getAktivitasKuliahMahasiswa` and additionally applies a defensive PHP `usort` by `id_semester` (string ascending) on the returned `$academic` array, so the academic table (card 2) is always sorted oldest→newest semester regardless of API ordering. `id_semester` column remains visible.
+- **Changes:** `app/Controllers/Graduation.php` (add `order` + `usort` in `step()`).
 
 ### ENH-003 — Remove two unused inputs; make academic table inline-editable, stored in wizard
 - **Status:** `verified`


### PR DESCRIPTION
## Summary

Sort the academic-history table in the PISN graduation wizard by `id_semester` ascending, via the Neo Feeder `order` parameter with a defensive PHP `usort` fallback, so semesters appear chronologically instead of in API-return order.

## Related issues

Fixes #86

## Checklist

- [x] `php -l` passes on all modified PHP files
- [ ] `npm run build` succeeds and committed assets are up to date (N/A - no asset changes)
- [ ] `php spark routes` shows correct new routes (N/A - no route changes)
- [x] `vendor/bin/php-cs-fixer fix` passes (no style violations)
- [x] `vendor/bin/phpunit` is green (if tests exist)
- [x] No debug code: `dd()`, `var_dump()`, `console.log()`, `print_r()`, `exit()`
- [ ] All user inputs validated server-side (N/A - no new user input)
- [ ] All POST forms include `csrf_field()` (N/A - no new POST form)
- [x] All HTML output uses `esc()`
- [x] No unrelated files changed
- [x] CHANGELOG updated if this is a user-facing change
- [x] Behaviour verified in the browser if UI changed

## Screenshot (if applicable)

## Notes for reviewers