### PR TITLE
feat: renumber graduation wizard steps to whole numbers (ENH-009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ _None yet._
 - **PISN graduation wizard:** removed the unused `academic_flag` textarea and `biaya_kuliah` input; the academic table (card 2) is now inline-editable per semester — `status` as a dropdown sourced from Neo Feeder `GetStatusMahasiswa`, plus editable `ips`/`ipk` — with corrections pushed to Neo Feeder via `updatePerkuliahanMahasiswa` at submission — ENH-003, #87
 - **PISN graduation wizard:** sorts the academic verification table (card 2) by `id_semester` ascending (oldest→newest), via API `order` plus a defensive `usort` fallback — ENH-002, #86
 - **PISN graduation wizard:** formats the step 4 "Input Kelulusan" inputs to match Neo Feeder — `jenis_keluar` is a dropdown of PDDIKTI labels (stores the `id_jenis_keluar` code), `periode_keluar` is a semester dropdown (stores `id_semester`), `tgl_keluar` is a native date input (`YYYY-MM-DD`); the `InsertMahasiswaLulusDO` record is rebuilt to the live WS schema (`id_registrasi_mahasiswa` resolved, `id_jenis_keluar`, `tanggal_keluar`, `id_periode_keluar`, `ipk`, `nomor_ijazah`) — ENH-004, #88
+- **PISN graduation wizard:** renumbered the verification step cards from (`1`, `2`, `2b`, `3`, `4`) to whole numbers (`1`, `2`, `3`, `4`, `5`) — the Kelengkapan Transkrip card is now its own step 3 — ENH-009, #103
 
 ### Fixed
 

--- a/app/Views/graduation/wizard.php
+++ b/app/Views/graduation/wizard.php
@@ -113,7 +113,7 @@
             </div>
 
             <div class="card mb-3">
-                <div class="card-header"><i class="fas fa-clipboard-check"></i> 2b. Kelengkapan Transkrip</div>
+                <div class="card-header"><i class="fas fa-clipboard-check"></i> 3. Kelengkapan Transkrip</div>
                 <div class="card-body">
                     <?php if ($transcript === null): ?>
                         <div class="text-muted">Data transkrip tidak dapat dimuat.</div>
@@ -172,7 +172,7 @@
             </div>
 
             <div class="card mb-3">
-                <div class="card-header"><i class="fas fa-certificate"></i> 3. Eligibilitas PISN</div>
+                <div class="card-header"><i class="fas fa-certificate"></i> 4. Eligibilitas PISN</div>
                 <div class="card-body">
                     <?php if (! empty($pisn['available'])): ?>
                         <div class="text-info">Eligibilitas: <?= $pisn['eligible'] ? 'Ya' : 'Tidak' ?></div>
@@ -187,7 +187,7 @@
             </div>
 
             <div class="card mb-3">
-                <div class="card-header"><i class="fas fa-graduation-cap"></i> 4. Input Kelulusan</div>
+                <div class="card-header"><i class="fas fa-graduation-cap"></i> 5. Input Kelulusan</div>
                 <div class="card-body">
                     <?php
                         $g = $student['graduation']

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -186,12 +186,12 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** `—`
 
 ### ENH-009 — Simplify step numbering (whole numbers, no 2b)
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #103
 - **Recorded:** 2026-08-30 15:18
-- **Implemented:** `—`
+- **Implemented:** 2026-08-30 16:20
 - **Problem:** The wizard uses `2b` as a step label (Kelengkapan Transkrip card is currently numbered as a sub-step of the academic step), which looks inconsistent alongside whole-numbered steps 1, 2, 3, 4.
 - **Possible Fix:** Two options were considered: (a) remove step numbering entirely, or (b) renumber all steps to whole numbers with no sub-step. **Decision (AGENT): option (b)** — renumber the transcript card from `2b` to its own whole number (2b → 3, and 3/4 shift accordingly), preserving the wizard's "which step am I on" orientation without sub-numbering.
 - **Actual Fix:** In `wizard.php` card headers (lines 34, 58, 116, 175, 190) renumber to: `1. Identitas (cocok dengan KTP)`, `2. Akademik (status, IPK, SKS)`, `3. Kelengkapan Transkrip`, `4. Eligibilitas PISN`, `5. Input Kelulusan`. No other structural change; the transcript card becomes its own whole-numbered step. Any step references in ENH-008 (checkbox labels) and in the Upload/preview views must follow the same renumbering. (Verified the current labels: `1.`, `2.`, `2b.`, `3.`, `4.`.)
-- **Actual Implemented:** `—`
-- **Changes:** `—`
+- **Actual Implemented:** Renumbered the five wizard card headers in `app/Views/graduation/wizard.php` to whole numbers: `1. Identitas`, `2. Akademik`, `3. Kelengkapan Transkrip`, `4. Eligibilitas PISN`, `5. Input Kelulusan` (the former `2b. Kelengkapan Transkrip` became `3.`, and the old `3.`/`4.` shifted to `4.`/`5.`). No structural or logic change; the card order is unchanged. Verified no other view references step numbers (upload/preview render none).
+- **Changes:** Wizard step sequence is now a clean `1..5` with no sub-numbered step; the transcript card is its own whole-numbered step.


### PR DESCRIPTION
## Summary

Renumbers the PISN graduation wizard verification step cards from (`1`, `2`, `2b`, `3`, `4`) to whole numbers (`1`, `2`, `3`, `4`, `5`). The "Kelengkapan Transkrip" card is now its own step 3, removing the inconsistent `2b` sub-step label. No logika atau struktur berubah — hanya label header kartu.

## Related issues

Fixes #103

## Checklist

- [x] `php -l` passes on all modified PHP files
- [x] `npm run build` succeeds and committed assets are up to date
- [x] `vendor/bin/php-cs-fixer fix` passes (no style violations)
- [x] `vendor/bin/phpunit` is green (if tests exist)
- [x] No debug code: `dd()`, `var_dump()`, `console.log()`, `print_r()`, `exit()`
- [x] No unrelated files changed
- [x] CHANGELOG updated if this is a user-facing change
- [x] Behaviour verified in the browser (rendered wizard shows steps `1.`–`5.` with no `2b`; upload/preview unaffected; test wizard session cancelled, no Neo Feeder mutation)

## Notes for reviewers

Verifikasi pulpuh label dilakukan terhadap wizard.php card headers (5 kartu: `1. Identitas`, `2. Akademik`, `3. Kelengkapan Transkrip`, `4. Eligibilitas PISN`, `5. Input Kelulusan`). Tidak ada referensi nomor step lain di view upload/preview. Penomoran baru menjadi dasar label checkbox pada ENH-008.