### PR TITLE
docs: commit ARCHITECTURE and STRUCTURE documentation updates (DOC-001)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,6 +71,26 @@ Filter ordering: **Required before** → **Global before** → Route → Control
 | POST | `/logout` | `Login::logout` | Protected | Enabled |
 | GET | `/dashboard` | `Dashboard::index` | Protected | — |
 | GET | `/profil-pt` | `ProfilPT::index` | Protected | — |
+| GET | `/mahasiswa` | `Mahasiswa::index` | Protected | — |
+| GET | `/mahasiswa/edit/(:any)` | `Mahasiswa::edit/$1` | Protected | — |
+| GET | `/mahasiswa/detail/(:any)` | `Mahasiswa::detail/$1` | Protected | — |
+| POST | `/mahasiswa/edit/(:any)` | `Mahasiswa::editPost/$1` | Protected | Enabled |
+| POST | `/mahasiswa/delete/(:any)` | `Mahasiswa::delete/$1` | Protected | Enabled |
+| GET | `/aktivitas-kuliah` | `AktivitasKuliah::index` | Protected | — |
+| GET | `/aktivitas-kuliah/edit/(:any)/(:any)` | `AktivitasKuliah::edit/$1/$2` | Protected | — |
+| POST | `/aktivitas-kuliah/edit/(:any)/(:any)` | `AktivitasKuliah::editPost/$1/$2` | Protected | Enabled |
+| POST | `/aktivitas-kuliah/delete/(:any)/(:any)` | `AktivitasKuliah::delete/$1/$2` | Protected | Enabled |
+| GET | `/mahasiswa-lulus-do` | `MahasiswaLulusDo::index` | Protected | — |
+| GET | `/graduation` | `Graduation::index` | Protected | — |
+| POST | `/graduation/upload` | `Graduation::upload` | Protected | Enabled |
+| GET | `/graduation/resume` | `Graduation::resume` | Protected | — |
+| GET | `/graduation/step` | `Graduation::step` | Protected | — |
+| POST | `/graduation/step` | `Graduation::stepPost` | Protected | Enabled |
+| GET | `/graduation/preview` | `Graduation::preview` | Protected | — |
+| POST | `/graduation/finish` | `Graduation::finish` | Protected | Enabled |
+| GET | `/graduation/guidance` | `Graduation::guidance` | Protected | — |
+| GET | `/graduation/template` | `Graduation::downloadTemplate` | Protected | — |
+| POST | `/graduation/cancel` | `Graduation::cancel` | Protected | Enabled |
 
 ---
 
@@ -83,10 +103,16 @@ Filter ordering: **Required before** → **Global before** → Route → Control
 | `Login` | `Controllers/Login.php` | Login form, login attempt, logout | `Auth` service |
 | `Dashboard` | `Controllers/Dashboard.php` | Protected landing page | `Auth` service, 4 views |
 | `ProfilPT` | `Controllers/ProfilPT.php` | PT profile page: formats `GetProfilPT` data (SK date to Indonesian, website URL normalization) | `Auth`, `NeoFeeder` services, view `profil_pt/index` |
+| `Mahasiswa` | `Controllers/Mahasiswa.php` | CRUD for student biodata: list, detail (read-only), edit, update, delete | `Auth`, `NeoFeeder` services, views `mahasiswa/` |
+| `AktivitasKuliah` | `Controllers/AktivitasKuliah.php` | CRUD for course activities: list, edit, update, delete | `Auth`, `NeoFeeder` services, views `aktivitas_kuliah/` |
+| `MahasiswaLulusDo` | `Controllers/MahasiswaLulusDo.php` | Read-only list of graduated/dropped-out students | `Auth`, `NeoFeeder` services, view `mahasiswa_lulus_do/index` |
+| `Graduation` | `Controllers/Graduation.php` | PISN graduation wizard: Excel upload, sequential verification, pre-submit preview, template download, cancellation, transcript completeness check | `Auth`, `NeoFeeder`, `PisnService`, `WizardProgress` services, views `graduation/` |
 | `AuthFilter` | `Filters/AuthFilter.php` | Route protection middleware | `Auth` service, CI4 Session |
-| `Auth` | `Libraries/Auth.php` | Auth logic: login, logout, validate, caching | `NeoFeeder`, `Session`, `EncrypterInterface` |
-| `NeoFeeder` | `Libraries/NeoFeeder.php` | HTTP layer for Neo Feeder API | `NeoFeederConfig`, `CURLRequest` |
+| `Auth` | `Libraries/Auth.php` | Auth logic: login, logout, validate, caching, wizard resume cookie | `NeoFeeder`, `Session`, `EncrypterInterface` |
+| `NeoFeeder` | `Libraries/NeoFeeder.php` | HTTP layer for Neo Feeder API: GetProfilPT, GetToken, GetListMahasiswa, GetAktivitasKuliahMahasiswa, GetListMahasiswaLulusDO, GetCountMahasiswa, GetCountAktivitasKuliahMahasiswa, GetCountMahasiswaLulusDO, GetTranskripMahasiswa, GetBiodataMahasiswa, GetDetailPerkuliahanMahasiswa, InsertMahasiswaLulusDO, Insert/Update/Delete BiodataMahasiswa, Insert/Update/Delete PerkuliahanMahasiswa | `NeoFeederConfig`, `CURLRequest` |
 | `NeoFeeder` (Config) | `Config/NeoFeeder.php` | API base URL, timeouts, TTL | — |
+| `PisnService` | `Libraries/PisnService.php` | PISN eligibility check (stubbed, awaiting LLDIKTI API) | — |
+| `WizardProgress` | `Libraries/WizardProgress.php` | Cache-backed progress store for graduation wizard (survives auth expiry) | CI4 `CacheInterface` |
 
 ### Dependency Injection Chain
 
@@ -96,9 +122,15 @@ Services::auth()
 
 Services::neoFeeder()
   └─> NeoFeeder(NeoFeederConfig, CURLRequest)
+
+Services::wizardProgress()
+  └─> WizardProgress(Cache)
+
+Services::pisn()
+  └─> PisnService()
 ```
 
-Both registered as singletons in `app/Config/Services.php`.
+All registered as singletons in `app/Config/Services.php`.
 
 ---
 
@@ -158,6 +190,18 @@ validateToken():
 
 When CI4 session expires but the prior-auth cookie still exists, the Auth Filter detects this and shows "Your session has expired" instead of a silent redirect. This distinguishes "never logged in" from "session timed out."
 
+### Wizard Resume Cookie (Graduation Wizard Survivability)
+
+The graduation wizard persists progress in the CI4 cache (`WizardProgress`) keyed by an opaque token. That token is also stored in a `wizard_resume` cookie (24h, httpOnly, SameSite=Lax, no encryption — opaque random value). This allows the wizard to survive auth-session expiry: after re-login, the cookie is read, the cached progress is loaded, and the admin continues from the interrupted step. The cookie is cleared on wizard completion (`finish`) or explicit cancellation (`cancel`).
+
+```
+wizard_resume: <32-char-hex-token>
+    ├── expires: +24 hours
+    ├── httpOnly: true
+    ├── sameSite: Lax
+    └── secure: true (production)
+```
+
 ---
 
 ## Data Model
@@ -171,7 +215,7 @@ auth (namespace)
 └── lastValidatedAt: int    # Unix timestamp of last GetProfilPT success
 ```
 
-### Cookie
+### Cookies
 
 ```
 prior_auth: base64(encrypt(username | hmac(token)))
@@ -179,7 +223,106 @@ prior_auth: base64(encrypt(username | hmac(token)))
     ├── httpOnly: true
     ├── sameSite: Lax
     └── secure: true (production)
+
+wizard_resume: <32-char-hex-token>
+    ├── expires: +24 hours
+    ├── httpOnly: true
+    ├── sameSite: Lax
+    └── secure: true (production)
 ```
+
+---
+
+## Graduation Wizard Flow
+
+The PISN graduation wizard guides an admin through sequential verification of each prospective graduate:
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant GradCtrl as Graduation Controller
+    participant WizProg as WizardProgress (Cache)
+    participant NeoFdrSvc as NeoFeeder Service
+    participant NeoFdrAPI as Neo Feeder API
+    participant AuthSvc as Auth Service
+
+    Browser->>GradCtrl: GET /graduation
+    GradCtrl-->>Browser: Upload form (with resume prompt if cookie exists)
+
+    Browser->>GradCtrl: POST /graduation/upload (Excel)
+    GradCtrl->>GradCtrl: parse Excel → student list
+    GradCtrl->>WizProg: generateToken() + save(initialState)
+    GradCtrl->>AuthSvc: setWizardResumeCookie(token)
+    GradCtrl-->>Browser: redirect /graduation/step
+
+    loop Per Student (sequential)
+        Browser->>GradCtrl: GET /graduation/step
+        GradCtrl->>WizProg: load(token) → current student
+        GradCtrl->>NeoFdrSvc: getListMahasiswa (identity)
+        GradCtrl->>NeoFdrSvc: getAktivitasKuliahMahasiswa (academic)
+        GradCtrl->>NeoFdrSvc: getTranskripMahasiswa (transcript)
+        GradCtrl->>NeoFdrSvc: checkTranscriptCompleteness()
+        GradCtrl->>PisnService: checkEligibility() → manual confirmation
+        NeoFdrSvc->>NeoFdrAPI: API calls
+        NeoFdrAPI-->>NeoFdrSvc: JSON responses
+        GradCtrl-->>Browser: Wizard step view (identity/academic/transcript/PISN)
+
+        Browser->>GradCtrl: POST /graduation/step (verification + graduation fields)
+        GradCtrl->>GradCtrl: validate inputs
+        GradCtrl->>WizProg: save(updatedState with student.saved=true)
+        alt last student
+            GradCtrl-->>Browser: redirect /graduation/preview
+        else
+            GradCtrl-->>Browser: redirect /graduation/step (next student)
+        end
+    end
+
+    Browser->>GradCtrl: GET /graduation/preview
+    GradCtrl->>WizProg: load(token) → all students
+    GradCtrl-->>Browser: Preview table (review all before submit)
+
+    Browser->>GradCtrl: POST /graduation/finish
+    GradCtrl->>WizProg: load(token)
+    loop Each saved student
+        GradCtrl->>NeoFdrSvc: insertMahasiswaLulusDO(record)
+        NeoFdrSvc->>NeoFdrAPI: POST InsertMahasiswaLulusDO
+        NeoFdrAPI-->>NeoFdrSvc: result
+    end
+    GradCtrl->>WizProg: clear(token)
+    GradCtrl->>AuthSvc: clearWizardResumeCookie()
+    GradCtrl-->>Browser: redirect /graduation/guidance (results)
+
+    Browser->>GradCtrl: POST /graduation/cancel
+    GradCtrl->>WizProg: clear(token)
+    GradCtrl->>AuthSvc: clearWizardResumeCookie()
+    GradCtrl-->>Browser: redirect /graduation (upload form)
+```
+
+### Wizard Step Verification
+
+Each step requires the admin to confirm four checks before advancing:
+
+1. **Identity** — Student matches KTP (`identity_ok` checkbox)
+2. **Academic** — Optional flag/notes (`academic_flag` text); if filled, `biaya_kuliah` required
+3. **PISN Eligibility** — Manual confirmation (`pisn_ok` checkbox; API deferred)
+4. **Graduation Fields** — NIM, name, jenis_keluar, tgl_keluar, periode_keluar, IPK, no_ijazah (default "-")
+
+Validation fails fast with aggregated errors; the step re-renders with input preserved.
+
+### Resumability
+
+- **Cache store** (`WizardProgress`): progress keyed by token, TTL 24h (default)
+- **Resume cookie** (`wizard_resume`): opaque token, survives CI4 session expiry
+- **Resume entry point**: `GET /graduation/resume` loads token from cookie, validates cache, redirects to `/graduation/step`
+- **Cancellation**: `POST /graduation/cancel` clears cache and cookie
+
+### Transcript Completeness Check (ENH-020)
+
+`Graduation::checkTranscriptCompleteness()` scans `GetTranskripMahasiswa` rows for a thesis/skripsi course (name matching `/skripsi|tugas\s*akhir|thesis|disertasi/i`) with a non-empty grade (`nilai_huruf` or `nilai_angka`). Returns `{complete: bool, reason: string}`. This is a heuristic — confirm naming against real data and tighten pattern if needed.
+
+### PISN Eligibility (Stubbed)
+
+`PisnService::checkEligibility()` currently returns `{available: false, eligible: null, reason: "PISN API not yet available..."}`. The wizard treats this as a manual confirmation step (`pisn_ok` checkbox). When LLDIKTI confirms the endpoint, plug the real adapter into `PisnService` without touching the wizard.
 
 ---
 
@@ -228,10 +371,10 @@ All assets are pre-compiled (no bundler). The build script copies files from `no
 ```
 app/
 ├── Config/          # NeoFeeder, Filters, Routes, Services
-├── Controllers/     # Login, Dashboard, ProfilPT, Home, BaseController
+├── Controllers/     # Login, Dashboard, ProfilPT, Home, BaseController, Mahasiswa, AktivitasKuliah, MahasiswaLulusDo, Graduation
 ├── Filters/         # AuthFilter (route protection)
-├── Libraries/       # Auth, NeoFeeder (service layer)
-└── Views/           # login/ (standalone), layout/ (header,sidebar,footer), dashboard/, profil_pt/
+├── Libraries/       # Auth, NeoFeeder, PisnService, WizardProgress (service layer)
+└── Views/           # login/ (standalone), layout/ (header,sidebar,footer), dashboard/, profil_pt/, mahasiswa/, aktivitas_kuliah/, mahasiswa_lulus_do/, graduation/
 public/              # index.php + built assets
 ├── adminlte/        # adminlte.min.css, adminlte.min.js
 ├── bootstrap/       # bootstrap.min.css, bootstrap.bundle.min.js

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -6,14 +6,14 @@
 [project-root]/
 ├── app/                  # CodeIgniter 4 application code (MVC)
 │   ├── Config/           # Routes, Filters, Services, NeoFeeder, env-driven config
-│   ├── Controllers/      # Home, Login, Dashboard, ProfilPT, BaseController
+│   ├── Controllers/      # Home, Login, Dashboard, ProfilPT, Mahasiswa, AktivitasKuliah, MahasiswaLulusDo, Graduation, BaseController
 │   ├── Filters/          # AuthFilter (route protection middleware)
-│   ├── Libraries/        # Auth, NeoFeeder (service layer)
+│   ├── Libraries/        # Auth, NeoFeeder, PisnService, WizardProgress (service layer)
 │   ├── Models/           # Empty (no local DB — placeholder .gitkeep)
 │   ├── Database/         # Migrations/ and Seeds/ (placeholder .gitkeep)
 │   ├── Helpers/          # Custom helpers (placeholder .gitkeep)
 │   ├── Language/en/      # Validation language strings
-│   ├── Views/            # login/, layout/, dashboard/, profil_pt/, errors/
+│   ├── Views/            # login/, layout/, dashboard/, profil_pt/, mahasiswa/, aktivitas_kuliah/, mahasiswa_lulus_do/, graduation/, errors/
 │   └── ThirdParty/       # Third-party code (placeholder .gitkeep)
 ├── public/               # Web root: index.php + pre-compiled assets
 │   ├── adminlte/         # adminlte.min.css, adminlte.min.js
@@ -44,7 +44,7 @@
 **`app/`:**
 - Purpose: All application code — controllers, services, filters, config, views.
 - Contains: PHP classes following CI4 MVC conventions
-- Key files: `app/Config/Routes.php`, `app/Config/Services.php`, `app/Config/Filters.php`, `app/Libraries/Auth.php`, `app/Libraries/NeoFeeder.php`
+- Key files: `app/Config/Routes.php`, `app/Config/Services.php`, `app/Config/Filters.php`, `app/Libraries/Auth.php`, `app/Libraries/NeoFeeder.php`, `app/Libraries/PisnService.php`, `app/Libraries/WizardProgress.php`
 
 **`app/Config/`:**
 - Purpose: Framework and app configuration classes
@@ -53,13 +53,13 @@
 
 **`app/Controllers/`:**
 - Purpose: HTTP request handlers
-- Contains: `Home`, `Login`, `Dashboard`, `ProfilPT`, abstract `BaseController`
-- Key files: `app/Controllers/ProfilPT.php` (PT profile page)
+- Contains: `Home`, `Login`, `Dashboard`, `ProfilPT`, `Mahasiswa`, `AktivitasKuliah`, `MahasiswaLulusDo`, `Graduation`, abstract `BaseController`
+- Key files: `app/Controllers/ProfilPT.php` (PT profile page), `app/Controllers/Mahasiswa.php` (student biodata CRUD + read-only detail), `app/Controllers/AktivitasKuliah.php` (course activity CRUD), `app/Controllers/Graduation.php` (PISN graduation wizard with preview, template download, cancellation), `app/Controllers/MahasiswaLulusDo.php` (graduated/dropped-out student list)
 
 **`app/Libraries/`:**
 - Purpose: Service layer — business logic decoupled from controllers
-- Contains: `Auth` (login, logout, token validation), `NeoFeeder` (HTTP client for the Neo Feeder API)
-- Key files: `app/Libraries/Auth.php`, `app/Libraries/NeoFeeder.php`
+- Contains: `Auth` (login, logout, token validation, wizard resume cookie), `NeoFeeder` (HTTP client for the Neo Feeder API), `PisnService` (PISN eligibility check, stubbed), `WizardProgress` (cache-backed progress store for graduation wizard)
+- Key files: `app/Libraries/Auth.php`, `app/Libraries/NeoFeeder.php`, `app/Libraries/PisnService.php`, `app/Libraries/WizardProgress.php`
 
 **`app/Filters/`:**
 - Purpose: Request middleware
@@ -68,8 +68,8 @@
 
 **`app/Views/`:**
 - Purpose: PHP view templates
-- Contains: `login/` (standalone), `layout/` (header, sidebar, footer), `dashboard/`, `profil_pt/`, `errors/`
-- Key files: `app/Views/layout/header.php`, `app/Views/layout/sidebar.php`, `app/Views/profil_pt/index.php`
+- Contains: `login/` (standalone), `layout/` (header, sidebar, footer), `dashboard/`, `profil_pt/`, `mahasiswa/`, `aktivitas_kuliah/`, `mahasiswa_lulus_do/`, `graduation/`, `errors/`
+- Key files: `app/Views/layout/header.php`, `app/Views/layout/sidebar.php`, `app/Views/layout/footer.php`, `app/Views/profil_pt/index.php`, `app/Views/mahasiswa/index.php`, `app/Views/mahasiswa/detail.php`, `app/Views/aktivitas_kuliah/index.php`, `app/Views/graduation/wizard.php`, `app/Views/graduation/upload.php`, `app/Views/graduation/preview.php`, `app/Views/graduation/guidance.php`
 
 **`public/`:**
 - Purpose: Web-accessible root; only files here are served
@@ -98,8 +98,8 @@
 
 **Entry Points:** `public/index.php`: CI4 front controller. `spark`: CI4 CLI entry point.
 **Configuration:** `app/Config/Routes.php`: route definitions. `app/Config/Services.php`: DI service registration. `app/Config/Filters.php`: required/global/route filters. `app/Config/NeoFeeder.php`: API base URL, timeouts, validation TTL.
-**Core Logic:** `app/Libraries/Auth.php`: authentication, token validation, prior-auth cookie. `app/Libraries/NeoFeeder.php`: Neo Feeder API HTTP layer.
-**Controllers:** `app/Controllers/`: `Login.php`, `Dashboard.php`, `ProfilPT.php`, `Home.php`, abstract `BaseController.php`.
+**Core Logic:** `app/Libraries/Auth.php`: authentication, token validation, prior-auth cookie, wizard resume cookie. `app/Libraries/NeoFeeder.php`: Neo Feeder API HTTP layer (GetProfilPT, GetToken, GetListMahasiswa, GetAktivitasKuliahMahasiswa, GetListMahasiswaLulusDO, GetCountMahasiswa, GetCountAktivitasKuliahMahasiswa, GetCountMahasiswaLulusDO, GetTranskripMahasiswa, GetBiodataMahasiswa, GetDetailPerkuliahanMahasiswa, InsertMahasiswaLulusDO, Insert/Update/Delete BiodataMahasiswa, Insert/Update/Delete PerkuliahanMahasiswa). `app/Libraries/PisnService.php`: PISN eligibility stub. `app/Libraries/WizardProgress.php`: wizard progress cache store.
+**Controllers:** `app/Controllers/`: `Login.php`, `Dashboard.php`, `ProfilPT.php`, `Home.php`, `Mahasiswa.php`, `AktivitasKuliah.php`, `MahasiswaLulusDo.php`, `Graduation.php`, abstract `BaseController.php`.
 **Middleware:** `app/Filters/AuthFilter.php`: route protection.
 **Tests:** `tests/unit/`: PHPUnit tests mirroring `app/Filters/` and `app/Libraries/`.
 **Assets:** `public/adminlte/`, `public/bootstrap/`, `public/fontawesome/`: pre-compiled from `node_modules/` via `npm run build`.
@@ -118,4 +118,5 @@
 **New filter:** `app/Filters/[FilterName].php` — register the alias in `app/Config/Filters.php`.
 **New view:** `app/Views/[view_group]/[page].php` — reuse `layout/header`, `layout/sidebar`, `layout/footer` for protected pages; standalone views for public pages.
 **New Neo Feeder API call:** add a method to `app/Libraries/NeoFeeder.php` using the private `sendRequest()` helper.
+**New wizard-style flow:** create a controller using `WizardProgress` (cache) + resume cookie via `Auth::setWizardResumeCookie()` / `getWizardResumeToken()` / `clearWizardResumeCookie()`; pre-submit preview via a dedicated route/method; cancellation via a POST route clearing cache and cookie; see `Graduation` for the pattern.
 **Tests:** `tests/unit/` mirroring the class under test, e.g. `tests/unit/Libraries/[ClassName]Test.php`.

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -220,15 +220,15 @@ The label is encoded directly in the ID prefix. When a valid item becomes a GitH
 - **Changes:** New `app/Controllers/VerifikasiIpk.php`, `app/Libraries/VerifikasiIpkStore.php`, `app/Views/verifikasi_ipk/*`; `NeoFeeder.php` gained `getListRiwayatPendidikanMahasiswa()`; routes + sidebar menu added.
 
 ### DOC-001 — Determine the fate of ARCHITECTURE.md & STRUCTURE.md (commit the pending documentation updates)
-- **Status:** `verified`
+- **Status:** `implemented`
 - **Issue:** #119
 - **Recorded:** 2026-08-31 15:42
-- **Implemented:** —
+- **Implemented:** 2026-08-31 16:09
 - **Problem:** `ARCHITECTURE.md` and `STRUCTURE.md` carry uncommitted changes left over from earlier sessions — they document features that were already implemented and merged (PISN routes and controllers `Mahasiswa`, `AktivitasKuliah`, `MahasiswaLulusDo`, `Graduation`; the `Auth`/`NeoFeeder`/`PisnService`/`WizardProgress` libraries; the graduation wizard flow and the wizard-resume cookie), yet they were deliberately left unstaged so they now drift from the actual code.
 - **Possible Fix:** Stage `ARCHITECTURE.md` + `STRUCTURE.md` and commit them atomically with a conventional `docs:` message, ending the deliberate hold and re-syncing the documentation with the current code.
 - **Actual Fix:** Commit the two files **as-is** (they already document the merged PISN features and match the code). Stage `ARCHITECTURE.md` + `STRUCTURE.md` from the saved stash and commit them atomically with a conventional `docs:` message. The docs are committed exactly as they stand — they are NOT extended to also cover the newer `VerifikasiIpk` controller/store/routes (out of scope for this item).
-- **Actual Implemented:** —
-- **Changes:** —
+- **Actual Implemented:** Committed `ARCHITECTURE.md` (+157) and `STRUCTURE.md` (+25/−19) as-is (extracted from the saved stash onto branch `docs/architecture-structure-commit` from `main`). The docs were NOT extended to cover `VerifikasiIpk` (kept out of scope per the Actual Fix).
+- **Changes:** `ARCHITECTURE.md` and `STRUCTURE.md` no longer drift from the code — the pending documentation of the merged PISN features (routes/controllers, libraries, wizard flow, resume cookie) is now committed and tracked in git.
 
 ### DOC-002 — Update README to reflect the current project state, including a record of the Neo Feeder API endpoints used (focus GetDictionary)
 - **Status:** `verified`


### PR DESCRIPTION
## Summary

Commits the pending `ARCHITECTURE.md` and `STRUCTURE.md` documentation updates that document the already-merged PISN features. The two files were long held out of scope (so they drifted from the code) and are now committed as-is.

## Related issues

Fixes #119

## Checklist

- [ ] `php -l` passes on all modified PHP files
- [ ] `npm run build` succeeds and committed assets are up to date
- [ ] `php spark routes` shows correct new routes (if routes changed)
- [ ] `vendor/bin/php-cs-fixer fix` passes (no style violations)
- [ ] `vendor/bin/phpunit` is green (if tests exist)
- [ ] No debug code: `dd()`, `var_dump()`, `console.log()`, `print_r()`, `exit()`
- [ ] All user inputs validated server-side
- [ ] All POST forms include `csrf_field()`
- [ ] All HTML output uses `esc()`
- [x] No unrelated files changed
- [ ] CHANGELOG updated if this is a user-facing change
- [ ] Behaviour verified in the browser if UI changed (attach a screenshot if useful)

## Screenshot (if applicable)

N/A — documentation-only change.

## Notes for reviewers

Markdown-only change: `ARCHITECTURE.md` (+157) and `STRUCTURE.md` (+25/-19), plus the tracker `docs/IMPROVEMENTS.md` (DOC-001 → implemented). No user-facing behaviour change, so no CHANGELOG entry.